### PR TITLE
Remove manual summary refresh button

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,12 +159,11 @@
                   <p>左側の共通チャットから送ったメッセージのポイントを確認できます。</p>
                 </div>
                 <div class="summary-actions">
-                  <button id="summarizeBtn" class="btn subtle" type="button">更新</button>
                   <button id="clearChatBtn" class="btn subtle" type="button">履歴クリア</button>
                 </div>
               </div>
               <div id="summaryBox" class="summary-box">
-                左側のチャットでメッセージを送信したら、「更新」を押して要約を反映します。
+                左側のチャットでメッセージを送信すると、ここに要約が表示されます。
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove the manual refresh control from the summary chat panel
- automatically recompute the summary whenever messages change and update the user guidance copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dddfa748f08320a859d955796c64d6