### PR TITLE
Add general navigation view to sidebar

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -36,6 +36,7 @@ const scheduleSidebarTogglePosition = () => {
 
 /* ---------- View switching ---------- */
 const views = {
+  general: $("#view-general"),
   browser: $("#view-browser"),
   iot: $("#view-iot"),
   chat: $("#view-chat"),
@@ -48,9 +49,13 @@ navButtons.forEach(btn => {
     const view = btn.dataset.view;
     navButtons.forEach(b => b.classList.toggle("active", b === btn));
     Object.entries(views).forEach(([k, el]) => el.classList.toggle("active", k === view));
-    appTitle.textContent =
-      view === "browser" ? "リモートブラウザ" :
-      view === "iot" ? "IoT ダッシュボード" : "要約チャット";
+    const titles = {
+      general: "一般ビュー",
+      browser: "リモートブラウザ",
+      iot: "IoT ダッシュボード",
+      chat: "要約チャット",
+    };
+    appTitle.textContent = titles[view] ?? "リモートブラウザ";
     scheduleSidebarTogglePosition();
   });
 });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -339,6 +339,26 @@ body{
 
 .view{display:none}
 .view.active{display:block}
+.general-view{
+  background:var(--panel-2);
+  border-radius:18px;
+  padding:28px;
+  box-shadow:var(--shadow);
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+.general-view h2{
+  margin:0;
+  font-size:24px;
+  font-weight:700;
+}
+.general-view p{
+  margin:0;
+  color:var(--muted);
+  font-size:15px;
+  line-height:1.8;
+}
 
 /* generic buttons */
 .btn{

--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
       <aside class="sidebar" role="navigation" aria-label="ビュー切替">
         <p class="sidebar-title">ビュー</p>
         <div class="sidebar-nav" role="group" aria-label="ビュー選択">
+          <button class="nav-btn" data-view="general" title="一般">
+          <!-- 一般ビュー用アイコン -->
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8.009 8.009 0 0 1-8 8zm0-11a3 3 0 1 0 3 3 3 3 0 0 0-3-3z"/>
+          </svg>
+          <span>一般</span>
+          </button>
           <button class="nav-btn active" data-view="browser" title="ブラウザ">
           <!-- モニタ風アイコン（SVG） -->
           <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -94,6 +101,14 @@
           <h1 class="content-title" id="appTitle">リモートブラウザ</h1>
           <p class="content-subtitle">左のサイドバーからビューを切り替えできます。</p>
         </header>
+        <!-- 0) 一般ビュー -->
+        <section id="view-general" class="view" aria-labelledby="appTitle">
+          <div class="general-view">
+            <h2>ようこそ</h2>
+            <p>左側のボタンから目的のビューを選択できます。ここでは全体の概要やお知らせを表示することができます。</p>
+          </div>
+        </section>
+
         <!-- 1) リモートブラウザ風ビュー -->
         <section id="view-browser" class="view active" aria-labelledby="appTitle">
           <div class="browser-controls" role="group" aria-label="リモートブラウザ設定">


### PR DESCRIPTION
## Summary
- add a new "一般" navigation button to the sidebar and corresponding general view section
- wire the general view into the single page app view switcher and page title logic
- style the general view container for consistent appearance with existing layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddf34e83ac832088c4d852b6256418