### PR TITLE
Improve FAQ_Gemini connectivity handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ pip install -r requirements.txt
 python app.py
 ```
 
-アプリケーションが `http://localhost:5050` で利用可能になります。
+アプリケーションが `http://localhost:5050` で利用可能になります。バックエンドの
+[FAQ_Gemini](https://github.com/kota-kawa/FAQ_Gemini/) サービスも別途起動してくだ
+さい (デフォルトでは `http://localhost:5000`)。
+
+必要に応じて Flask 側に FAQ_Gemini の接続先を環境変数で指定できます。複数の
+候補をカンマ区切りで指定すると、上から順に接続を試みます。
+
+```bash
+export FAQ_GEMINI_API_BASE="http://localhost:5000,http://faq_gemini:5000"
+python app.py
+```
 
 ## Docker Compose での起動
 
@@ -21,7 +31,10 @@ python app.py
 docker compose up --build
 ```
 
-ビルドと起動が完了すると、ブラウザで `http://localhost:5050` にアクセスできます。
+ビルドと起動が完了すると、ブラウザで `http://localhost:5050` にアクセスできま
+す。FAQ_Gemini を別コンテナで動かす場合は同じ Docker ネットワーク上で
+`faq_gemini` というホスト名になるよう起動してください (例: FAQ_Gemini リポジ
+トリの Dockerfile を利用して `docker run --name faq_gemini ...` など)。
 
 終了するには `Ctrl+C` を押すか、別のターミナルで次のコマンドを実行します。
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,6 @@ services:
     build: .
     ports:
       - "5050:5050"
+    environment:
+      FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add retryable FAQ_Gemini base URL resolution with docker-friendly defaults
- document how to configure the upstream FAQ_Gemini service and update compose env vars

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68de089ff2808320b434ac4afeda1ddd