### PR TITLE
Update Compose to join shared FAQ_Gemini network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,13 @@ services:
     ports:
       - "5050:5050"
     environment:
-      FAQ_GEMINI_API_BASE: "http://localhost:5000"
+      FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
     restart: unless-stopped
+    networks:
+      - default
+      - multi_agent_network
+
+networks:
+  multi_agent_network:
+    external: true
+    name: ${MULTI_AGENT_NETWORK:-multi_agent_platform_net}


### PR DESCRIPTION
## Summary
- attach the web container to the shared `multi_agent_network` so it can communicate with FAQ_Gemini
- add the external network definition that matches the FAQ_Gemini compose configuration
- extend the API base environment variable to try the `faq_gemini` host before falling back to localhost

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68de194706408320a68a4c0eb192c7a5