### PR TITLE
Enable live reload for docker compose development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ COPY . .
 
 EXPOSE 5050
 
-CMD ["python", "app.py"]
+ENV FLASK_APP=app.py
+
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5050", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       - "5050:5050"
     environment:
       FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
+      FLASK_DEBUG: "1"
+    volumes:
+      - .:/app
     restart: unless-stopped
     networks:
       - default


### PR DESCRIPTION
## Summary
- run the Flask app with the built-in reloader inside the container
- mount the local source tree and enable debug mode in docker-compose so code edits are picked up immediately

## Testing
- ❌ `docker compose config` *(fails: `docker` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de31d6cc548320a9914aafaec215a7