### PR TITLE
Add browser agent chat integration

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -56,8 +56,14 @@ navButtons.forEach(btn => {
       chat: "要約チャット",
     };
     appTitle.textContent = titles[view] ?? "リモートブラウザ";
-    if (view === "chat") {
-      ensureChatInitialized({ showLoadingSummary: true });
+    if (view === "browser") {
+      setChatMode("browser");
+      ensureBrowserAgentInitialized({ showLoading: true });
+    } else {
+      setChatMode("general");
+      if (view === "chat") {
+        ensureChatInitialized({ showLoadingSummary: true });
+      }
     }
     scheduleSidebarTogglePosition();
   });
@@ -330,6 +336,10 @@ const chatForm = $("#chatForm");
 const sidebarChatForm = $("#sidebarChatForm");
 const summaryBox = $("#summaryBox");
 const clearChatBtn = $("#clearChatBtn");
+const sidebarChatSend = $(".sidebar-chat-send");
+const sidebarChatUtilities = $(".sidebar-chat-utilities");
+const sidebarPauseBtn = $("#sidebarPauseBtn");
+const sidebarResetBtn = $("#sidebarResetBtn");
 
 const SUMMARY_PLACEHOLDER = "左側のチャットでメッセージを送信すると、ここに要約が表示されます。";
 const SUMMARY_LOADING_TEXT = "要約を取得しています…";
@@ -340,6 +350,20 @@ const chatState = {
   initialized: false,
   sending: false,
 };
+
+let currentChatMode = "general";
+
+const browserChatState = {
+  messages: [],
+  initialized: false,
+  sending: false,
+  paused: false,
+  agentRunning: false,
+  eventSource: null,
+  historyAbort: null,
+};
+
+const browserMessageIndex = new Map();
 
 function getIntroMessage() {
   return {
@@ -440,7 +464,17 @@ function createMessageElement(message, { compact = false } = {}) {
   return el;
 }
 
-function renderChat() {
+function renderSidebarMessages(messages) {
+  if (!sidebarChatLog) return;
+  sidebarChatLog.innerHTML = "";
+  const recent = messages.slice(-20);
+  recent.forEach(message => {
+    sidebarChatLog.appendChild(createMessageElement(message, { compact: true }));
+  });
+  sidebarChatLog.scrollTop = sidebarChatLog.scrollHeight;
+}
+
+function renderGeneralChat({ forceSidebar = false } = {}) {
   if (chatLog) {
     chatLog.innerHTML = "";
     chatState.messages.forEach(message => {
@@ -449,17 +483,320 @@ function renderChat() {
     chatLog.scrollTop = chatLog.scrollHeight;
   }
 
-  if (sidebarChatLog) {
-    sidebarChatLog.innerHTML = "";
-    const recent = chatState.messages.slice(-20);
-    recent.forEach(message => {
-      sidebarChatLog.appendChild(createMessageElement(message, { compact: true }));
-    });
-    sidebarChatLog.scrollTop = sidebarChatLog.scrollHeight;
+  if (forceSidebar || currentChatMode === "general") {
+    renderSidebarMessages(chatState.messages);
   }
 }
 
-renderChat();
+function renderBrowserChat({ forceSidebar = false } = {}) {
+  if (forceSidebar || currentChatMode === "browser") {
+    renderSidebarMessages(browserChatState.messages);
+  }
+}
+
+function resolveBrowserAgentBase() {
+  const sanitize = value => (typeof value === "string" ? value.trim().replace(/\/+$/, "") : "");
+  let queryBase = "";
+  try {
+    queryBase = new URLSearchParams(window.location.search).get("browser_agent_base") || "";
+  } catch (_) {
+    queryBase = "";
+  }
+  const sources = [
+    sanitize(queryBase),
+    sanitize(window.BROWSER_AGENT_API_BASE),
+    sanitize(document.querySelector("meta[name='browser-agent-api-base']")?.content),
+  ];
+  for (const src of sources) {
+    if (src) return src;
+  }
+  if (window.location.origin && window.location.origin !== "null") {
+    return window.location.origin.replace(/\/+$/, "");
+  }
+  return "http://localhost:5005";
+}
+
+const BROWSER_AGENT_API_BASE = resolveBrowserAgentBase();
+
+function buildBrowserAgentUrl(path) {
+  const normalizedPath = path.startsWith("http") ? path : path.startsWith("/") ? path : `/${path}`;
+  if (!BROWSER_AGENT_API_BASE) return normalizedPath;
+  const base = BROWSER_AGENT_API_BASE.replace(/\/+$/, "");
+  if (!base || base === window.location.origin.replace(/\/+$/, "")) {
+    return normalizedPath;
+  }
+  return `${base}${normalizedPath}`;
+}
+
+async function browserAgentRequest(path, { method = "GET", headers = {}, body, signal } = {}) {
+  const url = buildBrowserAgentUrl(path);
+  const finalHeaders = { ...headers };
+  const hasBody = body !== undefined && body !== null;
+  const isFormData = typeof FormData !== "undefined" && body instanceof FormData;
+  if (hasBody && !isFormData && !finalHeaders["Content-Type"]) {
+    finalHeaders["Content-Type"] = "application/json";
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: finalHeaders,
+    body,
+    signal,
+    mode: "cors",
+  });
+
+  const contentType = response.headers.get("content-type") || "";
+  const isJson = contentType.includes("application/json");
+  let data;
+  try {
+    data = isJson ? await response.json() : await response.text();
+  } catch (_) {
+    data = isJson ? {} : "";
+  }
+
+  if (!response.ok) {
+    const message = typeof data === "string" && data
+      ? data
+      : (data && typeof data.error === "string")
+        ? data.error
+        : `${response.status} ${response.statusText}`;
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
+  }
+
+  const payload = typeof data === "string" ? { message: data } : data;
+  return { data: payload, status: response.status };
+}
+
+function normalizeBrowserAgentMessage(raw) {
+  if (!raw || typeof raw !== "object") {
+    return { id: null, role: "system", text: "", ts: Date.now() };
+  }
+  const role = (raw.role || "").toLowerCase();
+  const normalizedRole = role === "user" ? "user" : role === "assistant" ? "assistant" : "system";
+  const text = typeof raw.content === "string" ? raw.content : "";
+  const parsedTs = raw.timestamp ? Date.parse(raw.timestamp) : Date.now();
+  const ts = Number.isFinite(parsedTs) ? parsedTs : Date.now();
+  return {
+    id: typeof raw.id === "number" ? raw.id : null,
+    role: normalizedRole,
+    text,
+    ts,
+  };
+}
+
+function setBrowserChatHistory(history, { forceSidebar = false } = {}) {
+  const converted = Array.isArray(history) ? history.map(normalizeBrowserAgentMessage) : [];
+  browserChatState.messages = converted.length ? converted : [
+    {
+      id: null,
+      role: "system",
+      text: "まだメッセージはありません。",
+      ts: Date.now(),
+    },
+  ];
+  browserMessageIndex.clear();
+  browserChatState.messages.forEach((message, index) => {
+    if (typeof message.id === "number") {
+      browserMessageIndex.set(message.id, index);
+    }
+  });
+  renderBrowserChat({ forceSidebar });
+}
+
+function appendBrowserChatMessage(raw) {
+  const message = normalizeBrowserAgentMessage(raw);
+  if (typeof message.id === "number" && browserMessageIndex.has(message.id)) {
+    const existingIndex = browserMessageIndex.get(message.id);
+    if (existingIndex !== undefined) {
+      browserChatState.messages[existingIndex] = message;
+    }
+  } else {
+    if (typeof message.id === "number") {
+      browserMessageIndex.set(message.id, browserChatState.messages.length);
+    }
+    browserChatState.messages.push(message);
+  }
+  renderBrowserChat();
+}
+
+function updateBrowserChatMessage(raw) {
+  const message = normalizeBrowserAgentMessage(raw);
+  if (typeof message.id === "number" && browserMessageIndex.has(message.id)) {
+    const index = browserMessageIndex.get(message.id);
+    if (index !== undefined) {
+      browserChatState.messages[index] = message;
+      renderBrowserChat();
+      return;
+    }
+  }
+  appendBrowserChatMessage(raw);
+}
+
+function addBrowserSystemMessage(text, { forceSidebar = false } = {}) {
+  if (!text) return;
+  browserChatState.messages.push({ id: null, role: "system", text, ts: Date.now() });
+  renderBrowserChat({ forceSidebar });
+}
+
+function updatePauseButtonState(mode = currentChatMode) {
+  if (!sidebarPauseBtn) return;
+  const showBrowserControls = mode === "browser";
+  sidebarPauseBtn.textContent = browserChatState.paused ? "再開" : "一時停止";
+  sidebarPauseBtn.setAttribute("aria-pressed", browserChatState.paused ? "true" : "false");
+  sidebarPauseBtn.disabled = !showBrowserControls || (!browserChatState.agentRunning && !browserChatState.paused);
+}
+
+function updateSidebarControlsForMode(mode) {
+  const showBrowserControls = mode === "browser";
+  if (sidebarChatUtilities) {
+    if (showBrowserControls) sidebarChatUtilities.removeAttribute("hidden");
+    else sidebarChatUtilities.setAttribute("hidden", "");
+  }
+  if (sidebarResetBtn) {
+    sidebarResetBtn.disabled = !showBrowserControls;
+  }
+  if (sidebarChatSend) {
+    sidebarChatSend.disabled = showBrowserControls ? browserChatState.sending : false;
+  }
+  updatePauseButtonState(mode);
+}
+
+function handleBrowserStatusEvent(payload) {
+  if (!payload || typeof payload !== "object") return;
+  if (typeof payload.agent_running === "boolean") {
+    browserChatState.agentRunning = payload.agent_running;
+    if (!payload.agent_running) {
+      browserChatState.paused = false;
+    }
+    updatePauseButtonState();
+  }
+}
+
+async function loadBrowserAgentHistory({ showLoading = false, forceSidebar = false } = {}) {
+  if (browserChatState.historyAbort) {
+    browserChatState.historyAbort.abort();
+  }
+  const controller = new AbortController();
+  browserChatState.historyAbort = controller;
+  if (showLoading) {
+    browserChatState.messages = [
+      { id: null, role: "system", text: "履歴を読み込んでいます…", pending: true, ts: Date.now() },
+    ];
+    browserMessageIndex.clear();
+    renderBrowserChat({ forceSidebar });
+  }
+  try {
+    const { data } = await browserAgentRequest("/api/history", { signal: controller.signal });
+    if (controller.signal.aborted) return;
+    setBrowserChatHistory(data.messages || [], { forceSidebar });
+  } catch (error) {
+    if (controller.signal.aborted) return;
+    browserChatState.messages = [
+      { id: null, role: "system", text: `履歴の取得に失敗しました: ${error.message}`, ts: Date.now() },
+    ];
+    browserMessageIndex.clear();
+    renderBrowserChat({ forceSidebar });
+  } finally {
+    if (browserChatState.historyAbort === controller) {
+      browserChatState.historyAbort = null;
+    }
+  }
+}
+
+function connectBrowserEventStream() {
+  if (typeof EventSource === "undefined") return;
+  if (browserChatState.eventSource) return;
+  try {
+    const streamUrl = buildBrowserAgentUrl("/api/stream");
+    const source = new EventSource(streamUrl);
+    source.onmessage = event => {
+      if (!event?.data) return;
+      let parsed;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch (error) {
+        console.error("ブラウザエージェントのイベント解析に失敗しました:", error);
+        return;
+      }
+      const { type, payload } = parsed || {};
+      if (type === "message") {
+        appendBrowserChatMessage(payload);
+      } else if (type === "update") {
+        updateBrowserChatMessage(payload);
+      } else if (type === "reset") {
+        browserMessageIndex.clear();
+        browserChatState.messages = [];
+        renderBrowserChat({ forceSidebar: currentChatMode === "browser" });
+        loadBrowserAgentHistory({ forceSidebar: currentChatMode === "browser" });
+      } else if (type === "status") {
+        handleBrowserStatusEvent(payload);
+      }
+    };
+    source.onerror = () => {
+      if (browserChatState.eventSource === source) {
+        source.close();
+        browserChatState.eventSource = null;
+        setTimeout(() => {
+          connectBrowserEventStream();
+        }, 4000);
+      }
+    };
+    browserChatState.eventSource = source;
+  } catch (error) {
+    console.error("ブラウザエージェントのイベントストリーム初期化に失敗しました:", error);
+  }
+}
+
+function ensureBrowserAgentInitialized({ showLoading = false } = {}) {
+  connectBrowserEventStream();
+  if (!browserChatState.initialized) {
+    browserChatState.initialized = true;
+    loadBrowserAgentHistory({ showLoading: true, forceSidebar: true });
+  } else {
+    loadBrowserAgentHistory({ showLoading, forceSidebar: true });
+  }
+}
+
+async function sendBrowserAgentPrompt(text) {
+  if (!text || browserChatState.sending) return;
+  connectBrowserEventStream();
+  browserChatState.sending = true;
+  browserChatState.agentRunning = true;
+  browserChatState.paused = false;
+  updateSidebarControlsForMode(currentChatMode);
+  try {
+    const payload = JSON.stringify({ prompt: text });
+    const { data } = await browserAgentRequest("/api/chat", { method: "POST", body: payload });
+    if (Array.isArray(data.messages)) {
+      setBrowserChatHistory(data.messages, { forceSidebar: currentChatMode === "browser" });
+    }
+    if (typeof data.run_summary === "string" && data.run_summary.trim()) {
+      // 既に履歴に含まれているため、ここでは追加しない
+    }
+  } catch (error) {
+    addBrowserSystemMessage(`送信に失敗しました: ${error.message}`, { forceSidebar: currentChatMode === "browser" });
+  } finally {
+    browserChatState.sending = false;
+    updateSidebarControlsForMode(currentChatMode);
+  }
+}
+
+function setChatMode(mode) {
+  if (mode !== "browser" && mode !== "general") {
+    mode = "general";
+  }
+  if (currentChatMode !== mode) {
+    currentChatMode = mode;
+  }
+  updateSidebarControlsForMode(mode);
+  if (mode === "browser") {
+    renderBrowserChat({ forceSidebar: true });
+  } else {
+    renderGeneralChat({ forceSidebar: true });
+  }
+}
 
 function setChatMessagesFromHistory(history) {
   const now = Date.now();
@@ -471,7 +808,7 @@ function setChatMessagesFromHistory(history) {
       }))
     : [];
   chatState.messages = [getIntroMessage(), ...converted];
-  renderChat();
+  renderGeneralChat();
 }
 
 async function syncConversationHistory({ showLoading = false, force = false } = {}) {
@@ -484,7 +821,7 @@ async function syncConversationHistory({ showLoading = false, force = false } = 
       getIntroMessage(),
       { role: "system", text: "会話履歴を取得しています…", pending: true, ts: Date.now() },
     ];
-    renderChat();
+    renderGeneralChat();
   }
   try {
     const data = await geminiRequest("/conversation_history");
@@ -499,7 +836,7 @@ async function syncConversationHistory({ showLoading = false, force = false } = 
         getIntroMessage(),
         { role: "system", text: `会話履歴の取得に失敗しました: ${error.message}`, ts: Date.now() },
       ];
-      renderChat();
+      renderGeneralChat();
     }
   }
 }
@@ -539,7 +876,7 @@ let pendingAssistantMessage = null;
 function addUserMessage(text) {
   const message = { role: "user", text, ts: Date.now() };
   chatState.messages.push(message);
-  renderChat();
+  renderGeneralChat();
   return message;
 }
 
@@ -550,7 +887,7 @@ function addPendingAssistantMessage() {
     pending: true,
   };
   chatState.messages.push(message);
-  renderChat();
+  renderGeneralChat();
   return message;
 }
 
@@ -571,7 +908,7 @@ async function sendChatMessage(text) {
       pendingAssistantMessage.pending = false;
       pendingAssistantMessage.ts = Date.now();
     }
-    renderChat();
+    renderGeneralChat();
     await syncConversationHistory({ force: true });
     if (isChatViewActive()) {
       await refreshSummaryBox({ showLoading: true });
@@ -584,7 +921,7 @@ async function sendChatMessage(text) {
       pendingAssistantMessage.text = `エラー: ${error.message}`;
       pendingAssistantMessage.pending = false;
       pendingAssistantMessage.ts = Date.now();
-      renderChat();
+      renderGeneralChat();
     }
   } finally {
     chatState.sending = false;
@@ -599,7 +936,8 @@ if (chatForm) {
     if (!value) return;
     chatInput.value = "";
     if (sidebarChatInput) sidebarChatInput.value = "";
-    await sendChatMessage(value);
+    if (currentChatMode === "browser") await sendBrowserAgentPrompt(value);
+    else await sendChatMessage(value);
   });
 }
 
@@ -610,7 +948,8 @@ if (sidebarChatForm) {
     if (!value) return;
     sidebarChatInput.value = "";
     if (chatInput) chatInput.value = "";
-    await sendChatMessage(value);
+    if (currentChatMode === "browser") await sendBrowserAgentPrompt(value);
+    else await sendChatMessage(value);
   });
 }
 
@@ -620,10 +959,62 @@ if (clearChatBtn) {
     try {
       await geminiRequest("/reset_history", { method: "POST" });
       chatState.messages = [getIntroMessage()];
-      renderChat();
+      renderGeneralChat({ forceSidebar: true });
       await refreshSummaryBox({ showLoading: true });
     } catch (error) {
       alert(`チャット履歴のクリアに失敗しました: ${error.message}`);
     }
   });
+}
+
+if (sidebarPauseBtn) {
+  sidebarPauseBtn.addEventListener("click", async () => {
+    if (currentChatMode !== "browser") return;
+    try {
+      if (browserChatState.paused) {
+        const { data } = await browserAgentRequest("/api/resume", { method: "POST" });
+        if (data && typeof data.status === "string") {
+          browserChatState.paused = data.status !== "resumed" ? browserChatState.paused : false;
+        } else {
+          browserChatState.paused = false;
+        }
+      } else {
+        const { data } = await browserAgentRequest("/api/pause", { method: "POST" });
+        if (data && typeof data.status === "string") {
+          browserChatState.paused = data.status === "paused";
+        } else {
+          browserChatState.paused = true;
+        }
+        browserChatState.agentRunning = true;
+      }
+    } catch (error) {
+      addBrowserSystemMessage(`一時停止操作に失敗しました: ${error.message}`, { forceSidebar: true });
+    } finally {
+      updatePauseButtonState();
+    }
+  });
+}
+
+if (sidebarResetBtn) {
+  sidebarResetBtn.addEventListener("click", async () => {
+    if (currentChatMode !== "browser") return;
+    if (!confirm("ブラウザエージェントの履歴をリセットしますか？")) return;
+    try {
+      const { data } = await browserAgentRequest("/api/reset", { method: "POST" });
+      browserChatState.paused = false;
+      browserChatState.agentRunning = false;
+      setBrowserChatHistory(data?.messages || [], { forceSidebar: true });
+      updateSidebarControlsForMode(currentChatMode);
+    } catch (error) {
+      addBrowserSystemMessage(`履歴のリセットに失敗しました: ${error.message}`, { forceSidebar: true });
+    }
+  });
+}
+
+const initialActiveView = document.querySelector(".nav-btn.active")?.dataset.view;
+if (initialActiveView === "browser") {
+  setChatMode("browser");
+  ensureBrowserAgentInitialized({ showLoading: true });
+} else {
+  setChatMode("general");
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -222,6 +222,29 @@ body{
   padding:12px;
   box-shadow:0 14px 34px rgba(7,16,32,.45);
 }
+.sidebar-chat-action-column{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  align-items:stretch;
+  min-width:0;
+}
+.sidebar-chat-utilities{
+  display:flex;
+  gap:8px;
+  justify-content:flex-end;
+}
+.sidebar-chat-utilities[hidden]{
+  display:none;
+}
+.sidebar-chat-control{
+  flex:1;
+  font-size:12px;
+  letter-spacing:.02em;
+  padding:10px 12px;
+  border-radius:12px;
+  white-space:nowrap;
+}
 .sidebar-chat-input{
   flex:1;
   width:100%;
@@ -755,6 +778,8 @@ body{
 @media (max-width: 520px){
   .sidebar-chat-form{gap:10px; padding:10px;}
   .sidebar-chat-input{min-height:56px; padding:12px 14px;}
+  .sidebar-chat-action-column{gap:8px;}
+  .sidebar-chat-control{font-size:11px; padding:8px 10px;}
   .sidebar-chat-send{width:44px; height:44px;}
 }
 

--- a/index.html
+++ b/index.html
@@ -68,14 +68,20 @@
               placeholder="ブラウザに指示したい内容を入力してください。"
               required
             ></textarea>
-            <button class="sidebar-chat-send" type="submit" aria-label="送信">
-              <span class="sr-only">送信</span>
-              <span aria-hidden="true" class="sidebar-chat-send-icon">
-                <svg viewBox="0 0 24 24" focusable="false">
-                  <path d="M5 12a1 1 0 0 1 1-1h9.586l-3.293-3.293a1 1 0 1 1 1.414-1.414l5 5a1 1 0 0 1 0 1.414l-5 5a1 1 0 1 1-1.414-1.414L15.586 13H6a1 1 0 0 1-1-1z" fill="currentColor" />
-                </svg>
-              </span>
-            </button>
+            <div class="sidebar-chat-action-column">
+              <button class="sidebar-chat-send" type="submit" aria-label="送信">
+                <span class="sr-only">送信</span>
+                <span aria-hidden="true" class="sidebar-chat-send-icon">
+                  <svg viewBox="0 0 24 24" focusable="false">
+                    <path d="M5 12a1 1 0 0 1 1-1h9.586l-3.293-3.293a1 1 0 1 1 1.414-1.414l5 5a1 1 0 0 1 0 1.414l-5 5a1 1 0 1 1-1.414-1.414L15.586 13H6a1 1 0 0 1-1-1z" fill="currentColor" />
+                  </svg>
+                </span>
+              </button>
+              <div class="sidebar-chat-utilities" hidden>
+                <button id="sidebarPauseBtn" class="btn subtle sidebar-chat-control" type="button">一時停止</button>
+                <button id="sidebarResetBtn" class="btn subtle sidebar-chat-control" type="button">履歴リセット</button>
+              </div>
+            </div>
           </form>
         </section>
       </aside>


### PR DESCRIPTION
## Summary
- add pause/reset controls beside the shared chat form for the browser view
- wire the shared chat to the browser agent API with mode switching, history sync, streaming updates, and pause/reset handlers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de38581fb48320924da595b757b082