### PR TITLE
Simplify browser view connection workflow

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -35,18 +35,6 @@ body{
 .content-title{margin:0; font-size:26px; font-weight:700}
 .content-subtitle{margin:0; font-size:14px; color:var(--muted)}
 
-.urlbar{
-  display:flex; align-items:center; gap:8px;
-  background:rgba(255,255,255,.12);
-  padding:6px 10px; border-radius:10px; min-width:240px; width:100%;
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,.12);
-}
-.urlbar .lock{opacity:.85}
-.url-input{
-  width:100%; background:transparent; border:none; color:#fff;
-  font-size:14px; outline:none
-}
-
 /* layout */
 .layout{
   display:flex;
@@ -397,42 +385,69 @@ body{
 .btn.large{font-size:18px; padding:12px 20px}
 
 /* browser */
-.browser-controls{
+.browser-info{
   background:var(--panel-2);
   border:1px solid var(--border);
   border-radius:var(--radius);
   padding:16px;
   box-shadow:var(--shadow);
-  display:flex;
-  flex-direction:column;
-  gap:12px;
+  margin-bottom:16px;
 }
-.url-label{margin:0; font-size:14px; font-weight:600}
-.url-control-row{
-  display:flex; gap:12px; align-items:center; flex-wrap:wrap;
+.browser-info-text{
+  margin:0;
+  font-size:14px;
+  color:var(--muted);
 }
-.url-control-row .urlbar{flex:1; min-width:240px}
-.url-control-row .btn{flex-shrink:0}
-.url-hint{margin:0; font-size:12px; color:var(--muted)}
+.browser-info-text code{
+  color:var(--accent);
+  font-family:inherit;
+}
 
-/* noVNC-like surface */
 .no-vnc-surface{
-  background:var(--panel-2); border:1px solid var(--border); border-radius:var(--radius);
-  padding:14px; box-shadow:var(--shadow);
+  background:var(--panel-2);
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  padding:14px;
+  box-shadow:var(--shadow);
 }
+
 .stage{
-  aspect-ratio:16/9; width:100%;
-  background:#0f1115; color:#c1cad7;
-  border-radius:10px; display:flex; align-items:center; justify-content:center; gap:18px;
-  position:relative; border:1px dashed #3b465e;
+  aspect-ratio:16/9;
+  width:100%;
+  background:#0f1115;
+  border-radius:10px;
+  border:1px solid var(--border);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:relative;
+  overflow:hidden;
+  color:#c1cad7;
 }
-.stage iframe{width:100%; height:100%; border:0; border-radius:8px; background:#0a0c10}
-.novnc-logo{position:absolute; top:25%; font-size:64px; font-weight:800; letter-spacing:.08em; opacity:.12}
-.stage .hint{position:absolute; bottom:10px; font-size:12px; color:#98a4b8; text-align:center; width:100%}
+
+.stage iframe{
+  width:100%;
+  height:100%;
+  border:0;
+  border-radius:8px;
+  background:#0a0c10;
+}
+
+.stage-fallback{
+  margin:0;
+  padding:24px;
+  color:var(--muted);
+  font-size:14px;
+  text-align:center;
+}
+
 .browser-toolbar{
-  display:flex; align-items:center; gap:8px; padding-top:10px;
+  display:flex;
+  justify-content:flex-end;
+  align-items:center;
+  gap:8px;
+  padding-top:10px;
 }
-.browser-toolbar .spacer{flex:1}
 
 /* IoT dashboard */
 .section-header{

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -117,30 +118,17 @@
 
         <!-- 1) リモートブラウザ風ビュー -->
         <section id="view-browser" class="view active" aria-labelledby="appTitle">
-          <div class="browser-controls" role="group" aria-label="リモートブラウザ設定">
-            <label class="url-label" for="urlInput">接続先 URL</label>
-            <div class="url-control-row">
-              <div class="urlbar">
-                <span class="lock" aria-hidden="true">🔒</span>
-                <input id="urlInput" class="url-input" type="text"
-                       value="http://127.0.0.1:7900/?autoconnect=1&resize=scale"
-                       aria-label="接続先 URL" />
-              </div>
-              <button id="connectBtn" class="btn primary" type="button" title="接続／切断">接続</button>
-            </div>
-            <p class="url-hint">必要に応じて URL を入力し、接続ボタンでリモート画面を表示します。</p>
+          <div class="browser-info" role="note" aria-live="polite">
+            <p class="browser-info-text">
+              ブラウザは常に接続済みです。以下のビューでは
+              <code>web_agent02</code> の構成と同じリモートブラウザが表示されます。
+            </p>
           </div>
           <div class="no-vnc-surface">
-            <div id="browserStage" class="stage stage--placeholder" role="region" aria-label="リモート映像">
-              <div class="novnc-logo" aria-hidden="true">noVNC</div>
-              <button id="stageConnect" class="btn ghost large" type="button">接続</button>
-              <p class="hint">上の入力欄で URL を変更できます（同一オリジンでない場合は埋め込みがブロックされることがあります）。</p>
+            <div id="browserStage" class="stage" role="region" aria-label="リモートブラウザ">
+              <p class="stage-fallback">リモートブラウザを読み込んでいます…</p>
             </div>
             <div class="browser-toolbar">
-              <button id="backBtn" class="btn subtle" type="button" title="戻る">←</button>
-              <button id="forwardBtn" class="btn subtle" type="button" title="進む">→</button>
-              <button id="reloadBtn" class="btn subtle" type="button" title="再読み込み">↻</button>
-              <div class="spacer"></div>
               <button id="fullscreenBtn" class="btn subtle" type="button" title="フルスクリーン">⤢</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Auto-mount the embedded browser iframe using the web_agent02-compatible URL and drop manual connect logic.
- Refresh the browser view markup and styling to remove the URL entry/back/forward controls and highlight the always-on session.

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68de3e5fedcc8320b96cec676d46159e