### PR TITLE
Configure browser chat to use running agent API

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -679,6 +679,19 @@ function handleBrowserStatusEvent(payload) {
     }
     updatePauseButtonState();
   }
+  if (typeof payload.run_summary === "string") {
+    const trimmed = payload.run_summary.trim();
+    if (trimmed) {
+      const alreadyExists = browserChatState.messages.some(
+        message => typeof message.text === "string" && message.text.trim() === trimmed,
+      );
+      if (!alreadyExists) {
+        addBrowserSystemMessage(trimmed, {
+          forceSidebar: currentChatMode === "browser",
+        });
+      }
+    }
+  }
 }
 
 async function loadBrowserAgentHistory({ showLoading = false, forceSidebar = false } = {}) {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale" />
+  <meta name="browser-agent-api-base" content="http://localhost:5005" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- expose the running web_agent02 API to the SPA via a meta configuration entry
- surface browser agent status summaries in the sidebar chat when they are not already in history

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68de48e194d88320b6ddecc1732983df