### PR TITLE
Improve sidebar chat layout and icon controls

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -347,6 +347,21 @@ const sidebarChatSend = $(".sidebar-chat-send");
 const sidebarChatUtilities = $(".sidebar-chat-utilities");
 const sidebarPauseBtn = $("#sidebarPauseBtn");
 const sidebarResetBtn = $("#sidebarResetBtn");
+const sidebarPauseIcon = sidebarPauseBtn?.querySelector(".sidebar-chat-control-icon");
+const sidebarPauseSr = sidebarPauseBtn?.querySelector(".sr-only");
+const sidebarResetIcon = sidebarResetBtn?.querySelector(".sidebar-chat-control-icon");
+
+const ICON_PAUSE = `<svg viewBox="0 0 24 24" focusable="false"><path fill="currentColor" d="M8 5h3v14H8zm5 0h3v14h-3z"/></svg>`;
+const ICON_PLAY = `<svg viewBox="0 0 24 24" focusable="false"><path fill="currentColor" d="M8 5.14v13.72a1 1 0 0 0 1.52.85l9.18-6.86a1 1 0 0 0 0-1.7L9.52 4.29A1 1 0 0 0 8 5.14z"/></svg>`;
+const ICON_RESET = `<svg viewBox="0 0 24 24" focusable="false"><path fill="currentColor" d="M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.75 10h-2.06A6 6 0 1 1 12 6a5.96 5.96 0 0 1 4.24 1.76L13 11h7V4z"/></svg>`;
+
+if (sidebarPauseIcon) {
+  sidebarPauseIcon.innerHTML = ICON_PAUSE;
+}
+
+if (sidebarResetIcon) {
+  sidebarResetIcon.innerHTML = ICON_RESET;
+}
 
 const SUMMARY_PLACEHOLDER = "左側のチャットでメッセージを送信すると、ここに要約が表示されます。";
 const SUMMARY_LOADING_TEXT = "要約を取得しています…";
@@ -650,8 +665,15 @@ function addBrowserSystemMessage(text, { forceSidebar = false } = {}) {
 function updatePauseButtonState(mode = currentChatMode) {
   if (!sidebarPauseBtn) return;
   const showBrowserControls = mode === "browser";
-  sidebarPauseBtn.textContent = browserChatState.paused ? "再開" : "一時停止";
+  const label = browserChatState.paused ? "再開" : "一時停止";
   sidebarPauseBtn.setAttribute("aria-pressed", browserChatState.paused ? "true" : "false");
+  sidebarPauseBtn.setAttribute("aria-label", label);
+  if (sidebarPauseSr) {
+    sidebarPauseSr.textContent = label;
+  }
+  if (sidebarPauseIcon) {
+    sidebarPauseIcon.innerHTML = browserChatState.paused ? ICON_PLAY : ICON_PAUSE;
+  }
   sidebarPauseBtn.disabled = !showBrowserControls || (!browserChatState.agentRunning && !browserChatState.paused);
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -202,47 +202,75 @@ body{
 }
 .sidebar-chat-form{
   display:flex;
-  gap:12px;
-  align-items:flex-end;
+  gap:14px;
+  align-items:stretch;
   background:linear-gradient(135deg, rgba(255,255,255,.12), rgba(91,209,255,.08));
   border:1px solid rgba(91,209,255,.22);
   border-radius:16px;
-  padding:12px;
+  padding:16px;
   box-shadow:0 14px 34px rgba(7,16,32,.45);
 }
 .sidebar-chat-action-column{
   display:flex;
   flex-direction:column;
-  gap:10px;
-  align-items:stretch;
+  gap:14px;
+  align-items:center;
+  justify-content:space-between;
   min-width:0;
+  align-self:stretch;
 }
 .sidebar-chat-utilities{
   display:flex;
-  gap:8px;
-  justify-content:flex-end;
+  gap:10px;
+  justify-content:center;
 }
 .sidebar-chat-utilities[hidden]{
   display:none;
 }
 .sidebar-chat-control{
-  flex:1;
-  font-size:12px;
-  letter-spacing:.02em;
-  padding:10px 12px;
-  border-radius:12px;
-  white-space:nowrap;
+  width:44px;
+  height:44px;
+  border-radius:14px;
+  border:1px solid rgba(91,209,255,.25);
+  background:linear-gradient(160deg, rgba(47,123,255,.18), rgba(26,91,255,.12));
+  color:var(--accent);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  transition:transform .18s ease, box-shadow .18s ease, border-color .18s ease, background .18s ease;
+  padding:0;
+}
+.sidebar-chat-control:disabled{
+  opacity:.55;
+  cursor:not-allowed;
+  box-shadow:none;
+}
+.sidebar-chat-control:not(:disabled):hover{
+  transform:translateY(-1px);
+  box-shadow:0 18px 30px rgba(16,44,102,.4);
+  border-color:rgba(91,209,255,.55);
+  background:linear-gradient(160deg, rgba(63,139,255,.32), rgba(26,91,255,.18));
+}
+.sidebar-chat-control:focus-visible{
+  outline:2px solid rgba(91,209,255,.75);
+  outline-offset:3px;
+}
+.sidebar-chat-control-icon svg{
+  width:18px;
+  height:18px;
+  display:block;
 }
 .sidebar-chat-input{
   flex:1;
   width:100%;
-  min-height:64px;
-  border-radius:14px;
-  border:1px solid rgba(86,132,205,.38);
-  background:linear-gradient(180deg, #f6f9ff 0%, #ebf1ff 100%);
+  min-height:92px;
+  border-radius:16px;
+  border:1px solid rgba(86,132,205,.42);
+  background:linear-gradient(180deg, #f6f9ff 0%, #e4edff 100%);
   color:#0f1f38;
-  padding:14px 16px;
-  font-size:13px;
+  padding:16px 18px;
+  font-size:14px;
   font-family:inherit;
   line-height:1.65;
   resize:vertical;

--- a/index.html
+++ b/index.html
@@ -80,8 +80,36 @@
                 </span>
               </button>
               <div class="sidebar-chat-utilities" hidden>
-                <button id="sidebarPauseBtn" class="btn subtle sidebar-chat-control" type="button">一時停止</button>
-                <button id="sidebarResetBtn" class="btn subtle sidebar-chat-control" type="button">履歴リセット</button>
+                <button
+                  id="sidebarPauseBtn"
+                  class="sidebar-chat-control"
+                  type="button"
+                  aria-label="一時停止"
+                  aria-pressed="false"
+                >
+                  <span class="sr-only">一時停止</span>
+                  <span class="sidebar-chat-control-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path fill="currentColor" d="M8 5h3v14H8zm5 0h3v14h-3z" />
+                    </svg>
+                  </span>
+                </button>
+                <button
+                  id="sidebarResetBtn"
+                  class="sidebar-chat-control"
+                  type="button"
+                  aria-label="履歴リセット"
+                >
+                  <span class="sr-only">履歴リセット</span>
+                  <span class="sidebar-chat-control-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path
+                        fill="currentColor"
+                        d="M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.75 10h-2.06A6 6 0 1 1 12 6a5.96 5.96 0 0 1 4.24 1.76L13 11h7V4z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
           </form>


### PR DESCRIPTION
## Summary
- expand the shared chat textarea and tweak the sidebar form layout to avoid the squeezed design
- replace the pause and reset text buttons with icon buttons and wire them to the existing control logic

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68e707aeceec83209a71c8d053926778