### PR TITLE
Remove redundant footer from demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,11 +209,6 @@
       </main>
     </div>
 
-    <footer class="footer" role="contentinfo">
-      <span>© 2025 Single Page Demo</span>
-      <span class="divider">•</span>
-      <span>デザイン参考：青系ツールバー & noVNC 風プレースホルダー</span>
-    </footer>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the single page demo footer so the page no longer shows the redundant copyright text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e70b45004c832090199871dc1135da