### PR TITLE
Keep browser chat controls consistent across views

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -56,15 +56,12 @@ navButtons.forEach(btn => {
       chat: "要約チャット",
     };
     appTitle.textContent = titles[view] ?? "リモートブラウザ";
-    if (view === "browser") {
-      setChatMode("browser");
-      ensureBrowserAgentInitialized({ showLoading: true });
-    } else {
-      setChatMode("general");
-      if (view === "chat") {
-        ensureChatInitialized({ showLoadingSummary: true });
-      }
+    const isBrowserView = view === "browser";
+    if (view === "chat") {
+      ensureChatInitialized({ showLoadingSummary: true });
     }
+    ensureBrowserAgentInitialized({ showLoading: isBrowserView });
+    setChatMode("browser");
     scheduleSidebarTogglePosition();
   });
 });
@@ -1054,9 +1051,8 @@ if (sidebarResetBtn) {
 }
 
 const initialActiveView = document.querySelector(".nav-btn.active")?.dataset.view;
-if (initialActiveView === "browser") {
-  setChatMode("browser");
-  ensureBrowserAgentInitialized({ showLoading: true });
-} else {
-  setChatMode("general");
+if (initialActiveView === "chat") {
+  ensureChatInitialized({ showLoadingSummary: true });
 }
+ensureBrowserAgentInitialized({ showLoading: initialActiveView === "browser" });
+setChatMode("browser");


### PR DESCRIPTION
## Summary
- always initialize the browser agent chat sidebar regardless of the active view so the UI stays consistent
- keep the sidebar chat mode set to browser, while still loading the summary view when requested

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e70cc02da483208a216444a7caeec2