### PR TITLE
Switch chat routing based on active view

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -57,11 +57,16 @@ navButtons.forEach(btn => {
     };
     appTitle.textContent = titles[view] ?? "リモートブラウザ";
     const isBrowserView = view === "browser";
-    if (view === "chat") {
+    const isChatView = view === "chat";
+    if (isChatView) {
       ensureChatInitialized({ showLoadingSummary: true });
+    } else if (!isBrowserView) {
+      ensureChatInitialized();
     }
-    ensureBrowserAgentInitialized({ showLoading: isBrowserView });
-    setChatMode("browser");
+    if (isBrowserView) {
+      ensureBrowserAgentInitialized({ showLoading: true });
+    }
+    setChatMode(isBrowserView ? "browser" : "general");
     scheduleSidebarTogglePosition();
   });
 });
@@ -1051,8 +1056,14 @@ if (sidebarResetBtn) {
 }
 
 const initialActiveView = document.querySelector(".nav-btn.active")?.dataset.view;
-if (initialActiveView === "chat") {
+const initialIsBrowser = initialActiveView === "browser";
+const initialIsChat = initialActiveView === "chat";
+if (initialIsChat) {
   ensureChatInitialized({ showLoadingSummary: true });
+} else if (!initialIsBrowser) {
+  ensureChatInitialized();
 }
-ensureBrowserAgentInitialized({ showLoading: initialActiveView === "browser" });
-setChatMode("browser");
+if (initialIsBrowser) {
+  ensureBrowserAgentInitialized({ showLoading: true });
+}
+setChatMode(initialIsBrowser ? "browser" : "general");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - "5050:5050"
     environment:
       FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
+      BROWSER_AGENT_API_BASE: "http://browser_agent:5005,http://localhost:5005"
       FLASK_DEBUG: "1"
     volumes:
       - .:/app


### PR DESCRIPTION
## Summary
- route the shared chat input to the browser control agent only when the browser view is active
- keep the FAQ Gemini-based workflow for the chat view and initialize the appropriate data when switching views
- expose the browser agent API base setting through docker-compose for easier configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e70fb74db08320869c2c5061793c80