### PR TITLE
Enhance assistant thinking state visuals

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -481,8 +481,33 @@ function createMessageElement(message, { compact = false } = {}) {
 
   const time = message.ts ? new Date(message.ts).toLocaleString("ja-JP") : "";
   const text = message.text ?? "";
+  const escapedText = escapeHTML(text);
+
+  if (message.role === "assistant" && message.pending) {
+    el.classList.add("thinking");
+    el.innerHTML = `
+      <div class="thinking-header">
+        <span class="thinking-orb" aria-hidden="true"></span>
+        <span class="thinking-labels">
+          <span class="thinking-title">AI が考えています</span>
+          <span class="thinking-sub">見つけた情報から回答を組み立て中…</span>
+        </span>
+      </div>
+      <div class="thinking-body">
+        <p class="thinking-text">${escapedText || "回答を生成しています…"}</p>
+        <div class="thinking-steps" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+      </div>
+      ${time ? `<span class="msg-time">${time}</span>` : ""}
+    `;
+    return el;
+  }
+
   el.innerHTML = `
-      ${escapeHTML(text)}
+      ${escapedText}
       ${time ? `<span class="msg-time">${time}</span>` : ""}
     `;
   return el;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -714,6 +714,112 @@ body{
 .msg.user{align-self:flex-end; background:#2d3b57; border:1px solid #3e4b6b}
 .msg.system,
 .msg.assistant{align-self:flex-start; background:#1f2738; border:1px solid #33405d}
+.msg.assistant.thinking{
+  position:relative;
+  padding:16px 18px;
+  border-radius:16px;
+  background:linear-gradient(160deg, rgba(44,78,132,.92), rgba(20,36,70,.88));
+  border:1px solid rgba(91,209,255,.4);
+  box-shadow:0 18px 36px rgba(6,14,32,.55);
+  overflow:hidden;
+  color:#e6f0ff;
+}
+.msg.assistant.thinking.pending{opacity:1; font-style:normal;}
+.msg.assistant.thinking::before{
+  content:"";
+  position:absolute;
+  inset:-140% -60%;
+  background:conic-gradient(from 90deg at 50% 50%, rgba(91,209,255,.1), rgba(22,118,255,.25), rgba(91,209,255,.1));
+  animation:thinkingGlow 6s linear infinite;
+  opacity:.7;
+}
+.msg.assistant.thinking::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  background:radial-gradient(120% 140% at 20% 20%, rgba(91,209,255,.18), transparent 55%);
+  pointer-events:none;
+  mix-blend-mode:screen;
+}
+.thinking-header{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  margin-bottom:12px;
+  position:relative;
+  z-index:1;
+}
+.thinking-labels{display:flex; flex-direction:column; gap:2px;}
+.thinking-title{font-size:13px; font-weight:600; letter-spacing:.04em; text-transform:none;}
+.thinking-sub{font-size:11px; color:rgba(230,233,239,.75); letter-spacing:.02em;}
+.thinking-orb{
+  width:14px;
+  height:14px;
+  border-radius:999px;
+  background:var(--accent);
+  box-shadow:0 0 18px rgba(91,209,255,.8);
+  position:relative;
+}
+.thinking-orb::after{
+  content:"";
+  position:absolute;
+  inset:-5px;
+  border-radius:inherit;
+  border:2px solid rgba(91,209,255,.6);
+  opacity:.9;
+  animation:thinkingOrbPulse 2s ease-in-out infinite;
+}
+.thinking-body{
+  position:relative;
+  z-index:1;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.thinking-text{
+  margin:0;
+  padding:12px 14px;
+  background:rgba(8,16,32,.6);
+  border-radius:14px;
+  border:1px solid rgba(91,209,255,.3);
+  font-size:13px;
+  line-height:1.75;
+  color:#dce6f7;
+  white-space:pre-wrap;
+}
+.thinking-steps{
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+.thinking-steps span{
+  display:block;
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  background:rgba(91,209,255,.55);
+  box-shadow:0 0 10px rgba(91,209,255,.55);
+  animation:thinkingDot 1.35s ease-in-out infinite;
+}
+.thinking-steps span:nth-child(2){animation-delay:.2s;}
+.thinking-steps span:nth-child(3){animation-delay:.4s;}
+.msg.assistant.thinking .msg-time{
+  position:relative;
+  z-index:1;
+  display:block;
+  margin-top:14px;
+  opacity:.65;
+}
+.sidebar-chat-log .msg.assistant.thinking{
+  background:linear-gradient(160deg, rgba(38,66,110,.92), rgba(20,38,78,.85));
+  border:1px solid rgba(91,209,255,.45);
+  padding:16px;
+}
+.sidebar-chat-log .msg.assistant.thinking .thinking-text{
+  background:rgba(10,20,40,.55);
+  border-color:rgba(91,209,255,.4);
+}
 .msg.pending{opacity:.78; font-style:italic}
 .msg-time{display:block; opacity:.6; font-size:11px; margin-top:4px}
 .chat-form{display:flex; gap:8px; padding:10px; border-top:1px solid var(--border)}
@@ -833,6 +939,23 @@ body{
   .summary-actions{width:100%; justify-content:flex-start;}
 }
 .footer .divider{opacity:.4}
+
+@keyframes thinkingOrbPulse{
+  0%{transform:scale(.8); opacity:.6;}
+  50%{transform:scale(1); opacity:1;}
+  100%{transform:scale(.8); opacity:.6;}
+}
+
+@keyframes thinkingDot{
+  0%, 100%{transform:translateY(0); opacity:.6;}
+  30%{transform:translateY(-4px); opacity:1;}
+  60%{transform:translateY(2px); opacity:.8;}
+}
+
+@keyframes thinkingGlow{
+  0%{transform:rotate(0deg);}
+  100%{transform:rotate(360deg);}
+}
 
 /* responsive */
 @media (max-width: 860px){


### PR DESCRIPTION
## Summary
- add an animated "AIが考えています" layout for pending assistant responses
- style the sidebar/chat logs with pulsing indicators to visualize answer generation

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e71246dc248320af31e9f37ea9f409