### PR TITLE
Show sidebar controls across all views

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -707,8 +707,7 @@ function updatePauseButtonState(mode = currentChatMode) {
 function updateSidebarControlsForMode(mode) {
   const showBrowserControls = mode === "browser";
   if (sidebarChatUtilities) {
-    if (showBrowserControls) sidebarChatUtilities.removeAttribute("hidden");
-    else sidebarChatUtilities.setAttribute("hidden", "");
+    sidebarChatUtilities.hidden = false;
   }
   if (sidebarResetBtn) {
     sidebarResetBtn.disabled = !showBrowserControls;

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                   </svg>
                 </span>
               </button>
-              <div class="sidebar-chat-utilities" hidden>
+              <div class="sidebar-chat-utilities">
                 <button
                   id="sidebarPauseBtn"
                   class="sidebar-chat-control"


### PR DESCRIPTION
## Summary
- keep the sidebar chat utility controls rendered regardless of the selected view
- rely on existing disabling logic so the pause and reset buttons remain visible but inactive outside the browser view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e71804e32c8320b283a6d7e9948810