### PR TITLE
Remove browser helper copy and enlarge viewport

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -375,7 +375,7 @@ body{
 /* main content */
 .content{
   flex:1;
-  padding:24px;
+  padding:20px;
   display:flex;
   flex-direction:column;
   gap:24px;
@@ -420,35 +420,17 @@ body{
 .btn.large{font-size:18px; padding:12px 20px}
 
 /* browser */
-.browser-info{
-  background:var(--panel-2);
-  border:1px solid var(--border);
-  border-radius:var(--radius);
-  padding:16px;
-  box-shadow:var(--shadow);
-  margin-bottom:16px;
-}
-.browser-info-text{
-  margin:0;
-  font-size:14px;
-  color:var(--muted);
-}
-.browser-info-text code{
-  color:var(--accent);
-  font-family:inherit;
-}
-
 .no-vnc-surface{
   background:var(--panel-2);
   border:1px solid var(--border);
   border-radius:var(--radius);
-  padding:14px;
+  padding:12px;
   box-shadow:var(--shadow);
 }
 
 .stage{
-  aspect-ratio:16/9;
   width:100%;
+  height:clamp(420px, 70vh, 900px);
   background:#0f1115;
   border-radius:10px;
   border:1px solid var(--border);

--- a/index.html
+++ b/index.html
@@ -147,12 +147,6 @@
 
         <!-- 1) リモートブラウザ風ビュー -->
         <section id="view-browser" class="view active" aria-labelledby="appTitle">
-          <div class="browser-info" role="note" aria-live="polite">
-            <p class="browser-info-text">
-              ブラウザは常に接続済みです。以下のビューでは
-              <code>web_agent02</code> の構成と同じリモートブラウザが表示されます。
-            </p>
-          </div>
           <div class="no-vnc-surface">
             <div id="browserStage" class="stage" role="region" aria-label="リモートブラウザ">
               <p class="stage-fallback">リモートブラウザを読み込んでいます…</p>


### PR DESCRIPTION
## Summary
- remove the browser connection notice from the remote browser view
- reduce surrounding padding and expand the stage height to give the embedded browser more space

## Testing
- python app.py

------
https://chatgpt.com/codex/tasks/task_e_68e71c596c38832088fe7897fa31a3f1