### PR TITLE
Connect IoT dashboard to IoT Agent services

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -517,80 +517,109 @@ body{
   padding:4px 8px; border-radius:999px; font-size:12px
 }
 
+.iot-notice{
+  margin:16px 0;
+  padding:14px 16px;
+  border-radius:14px;
+  border:1px solid rgba(91,209,255,.28);
+  background:rgba(16,26,44,.85);
+  color:#d3e8ff;
+  box-shadow:0 0 0 1px rgba(91,209,255,.12) inset;
+  transition:.2s ease;
+}
+.iot-notice[data-kind="error"]{
+  border-color:rgba(239,83,80,.45);
+  background:rgba(50,12,18,.85);
+  color:#ffd6d3;
+  box-shadow:0 0 0 1px rgba(239,83,80,.22) inset;
+}
+.iot-notice[data-kind="success"]{
+  border-color:rgba(56,193,114,.38);
+  background:rgba(20,46,34,.85);
+  color:#c9f5db;
+  box-shadow:0 0 0 1px rgba(56,193,114,.2) inset;
+}
+
 .device-grid{
   display:grid;
-  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
-  gap:20px;
-  margin-bottom:16px;
+  grid-template-columns:repeat(auto-fit, minmax(300px, 1fr));
+  gap:22px;
+  margin-bottom:24px;
 }
+
 .device-card{
   position:relative;
   overflow:hidden;
+  padding:22px;
+  border-radius:18px;
   background:linear-gradient(160deg, rgba(26,33,48,.96), rgba(15,19,30,.94));
   border:1px solid rgba(91,209,255,.18);
-  border-radius:16px;
-  padding:20px;
+  box-shadow:var(--shadow);
   display:flex;
   flex-direction:column;
-  gap:20px;
-  box-shadow:var(--shadow);
+  gap:18px;
 }
+
 .device-card::before{
   content:"";
   position:absolute;
-  top:-60px; right:-70px;
-  width:200px; height:200px;
-  background:radial-gradient(circle at center, rgba(91,209,255,.28), transparent 70%);
-  opacity:.8;
+  inset:-80px auto auto -40px;
+  width:220px;
+  height:220px;
+  background:radial-gradient(circle at center, rgba(91,209,255,.25), transparent 70%);
   pointer-events:none;
+  opacity:.8;
 }
+
 .device-card-header{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:16px;
   position:relative;
   z-index:1;
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:16px;
 }
-.device-title{
+
+.device-summary{
   display:flex;
   align-items:center;
-  gap:14px;
+  gap:16px;
   min-width:0;
 }
+
 .device-icon{
-  width:48px;
-  height:48px;
-  border-radius:14px;
+  width:54px;
+  height:54px;
+  border-radius:16px;
   display:flex;
   align-items:center;
   justify-content:center;
   background:rgba(91,209,255,.12);
   color:var(--accent);
-  box-shadow:inset 0 0 0 1px rgba(91,209,255,.32);
+  box-shadow:inset 0 0 0 1px rgba(91,209,255,.28);
 }
-.device-icon svg{width:26px; height:26px}
-.device-icon.actuator{
-  background:rgba(23,125,229,.14);
-  color:var(--primary);
-  box-shadow:inset 0 0 0 1px rgba(23,125,229,.3);
-}
+
+.device-icon svg{width:28px; height:28px}
+
 .device-meta{display:flex; flex-direction:column; gap:4px; min-width:0}
 .device-name{
-  font-weight:700;
-  font-size:17px;
   margin:0;
+  font-size:18px;
+  font-weight:700;
   white-space:nowrap;
   overflow:hidden;
   text-overflow:ellipsis;
 }
-.device-type{
+
+.device-id{
+  margin:0;
   font-size:12px;
-  letter-spacing:.08em;
-  text-transform:uppercase;
-  color:rgba(201,214,233,.75);
+  color:rgba(200,214,235,.68);
+  letter-spacing:.05em;
 }
-.device-tools{display:flex; align-items:center; gap:8px}
+
+.device-actions{display:flex; gap:8px; flex-wrap:wrap}
+
 .icon-btn{
   width:34px;
   height:34px;
@@ -603,98 +632,141 @@ body{
   cursor:pointer;
   transition:.15s ease;
 }
+
 .icon-btn:hover{
   color:#fff;
   border-color:rgba(91,209,255,.55);
   background:rgba(33,47,72,.85);
 }
+
 .icon-btn:focus{outline:none; box-shadow:0 0 0 2px rgba(91,209,255,.3);}
+
 .device-body{
   position:relative;
   z-index:1;
   display:flex;
-  align-items:center;
-  justify-content:space-between;
-  gap:18px;
-  flex-wrap:wrap;
+  flex-direction:column;
+  gap:16px;
 }
+
+.device-stats{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+}
+
 .device-stat{
+  min-width:180px;
   flex:1;
-  min-width:170px;
   background:rgba(9,13,22,.82);
-  border:1px solid rgba(91,209,255,.16);
+  border:1px solid rgba(91,209,255,.14);
   border-radius:14px;
-  padding:16px 18px;
+  padding:14px 16px;
   display:flex;
   flex-direction:column;
-  gap:10px;
+  gap:6px;
 }
-.device-stat-label{font-size:12px; color:rgba(200,214,235,.7); letter-spacing:.08em}
-.device-reading{font-size:30px; font-weight:700; letter-spacing:.02em}
-.device-status-pill{
-  display:inline-flex;
-  align-items:center;
-  gap:10px;
-  padding:10px 18px;
-  border-radius:999px;
-  font-size:16px;
-  font-weight:600;
-  background:rgba(56,193,114,.18);
-  color:#c9f5db;
-  box-shadow:inset 0 0 0 1px rgba(56,193,114,.32);
-}
-.device-status-pill.off{
-  background:rgba(239,83,80,.16);
-  color:#ffd5d2;
-  box-shadow:inset 0 0 0 1px rgba(239,83,80,.32);
-}
-.status-dot{
-  width:12px;
-  height:12px;
-  border-radius:50%;
-  display:inline-block;
-  margin-right:4px;
-  box-shadow:0 0 0 2px rgba(12,20,32,.6);
-}
-.status-on{background:var(--good)}
-.status-off{background:#556070}
 
-.device-controls{
+.device-stat__label{font-size:12px; letter-spacing:.08em; color:rgba(200,214,235,.7)}
+.device-stat__value{font-size:15px; font-weight:600; color:#e3f1ff}
+
+.device-section{display:flex; flex-direction:column; gap:8px}
+.device-section__label{font-size:12px; letter-spacing:.12em; color:rgba(200,214,235,.68); text-transform:uppercase}
+.device-section__body{display:flex; flex-wrap:wrap; gap:8px; font-size:14px; color:#d8e7ff}
+
+.capability-badge{
+  padding:6px 10px;
+  border-radius:999px;
+  border:1px solid rgba(91,209,255,.25);
+  background:rgba(12,20,32,.8);
+  font-size:12px;
+  letter-spacing:.04em;
+}
+
+.meta-list{display:flex; flex-direction:column; gap:4px; font-size:13px; color:#ccd9f1}
+.meta-list__item{display:flex; gap:6px; align-items:flex-start}
+.meta-list__label{color:rgba(200,214,235,.6); min-width:80px; font-size:12px; letter-spacing:.08em; text-transform:uppercase}
+.meta-list__value{flex:1; word-break:break-word}
+
+.device-last-result{
   display:flex;
-  align-items:center;
-  gap:12px;
-  justify-content:flex-end;
-  flex:0 0 auto;
+  flex-direction:column;
+  gap:6px;
+  font-size:13px;
+  color:#d6e9ff;
+  background:rgba(18,28,44,.8);
+  border:1px solid rgba(91,209,255,.18);
+  border-radius:14px;
+  padding:12px 14px;
 }
-.device-controls .btn{padding:8px 14px; font-size:13px}
 
-/* toggle */
-.switch{
-  position:relative;
-  width:54px;
-  height:30px;
-  background:rgba(52,68,96,.75);
-  border-radius:999px;
-  border:1px solid rgba(91,209,255,.2);
-  box-shadow:inset 0 0 0 1px rgba(19,26,38,.9);
+.device-last-result__meta{font-size:12px; color:rgba(200,214,235,.65); display:flex; flex-wrap:wrap; gap:10px}
+
+.device-empty{
+  grid-column:1/-1;
+  padding:32px;
+  text-align:center;
+  border-radius:16px;
+  border:1px dashed rgba(91,209,255,.32);
+  background:rgba(13,20,32,.7);
+  color:#c8d7f2;
+}
+
+.collapsible-text{display:flex; flex-direction:column; gap:6px; font-size:13px; line-height:1.6}
+.collapsible-text__content{white-space:pre-wrap; word-break:break-word}
+.collapsible-text__toggle{
+  align-self:flex-start;
+  border:none;
+  background:none;
+  color:var(--accent);
   cursor:pointer;
-  transition:.25s background ease, .25s border-color ease;
+  font-size:12px;
+  padding:0;
+  text-decoration:underline;
 }
-.switch::after{
-  content:"";
-  position:absolute;
-  top:3px; left:3px;
-  width:24px; height:24px;
-  border-radius:50%;
-  background:#cfd9ea;
-  transition:.25s left ease, .25s background ease;
-  box-shadow:0 2px 10px rgba(0,0,0,.35);
+.collapsible-text__toggle:hover{color:#9fe8ff}
+
+.dialog{
+  border:none;
+  border-radius:18px;
+  padding:0;
+  background:transparent;
+  color:inherit;
 }
-.switch.on{
-  background:linear-gradient(135deg, rgba(56,193,114,.75), rgba(31,142,90,.85));
-  border-color:rgba(56,193,114,.45);
+
+.dialog::backdrop{background:rgba(7,10,18,.65); backdrop-filter:blur(2px)}
+
+.dialog-panel{
+  width:min(420px, calc(100vw - 32px));
+  background:linear-gradient(160deg, rgba(24,31,46,.95), rgba(12,17,26,.95));
+  border:1px solid rgba(91,209,255,.2);
+  border-radius:18px;
+  display:flex;
+  flex-direction:column;
+  max-height:90vh;
 }
-.switch.on::after{left:27px; background:#fff}
+
+.dialog-header{padding:20px 24px 12px; border-bottom:1px solid rgba(91,209,255,.12)}
+.dialog-header h3{margin:0; font-size:18px}
+
+.dialog-body{padding:18px 24px; display:flex; flex-direction:column; gap:16px; overflow-y:auto}
+.dialog-footer{padding:16px 24px 22px; display:flex; justify-content:flex-end; gap:12px; border-top:1px solid rgba(91,209,255,.12)}
+
+.dialog-message{font-size:13px; color:#c8d7f2; line-height:1.6}
+.dialog-message.error{color:#ffb3ad}
+.dialog-message.success{color:#c9f5db}
+
+.form-row{display:flex; flex-direction:column; gap:6px}
+.form-label{font-size:13px; letter-spacing:.05em; color:rgba(200,214,235,.75)}
+.form-control{
+  border-radius:10px;
+  border:1px solid rgba(91,209,255,.2);
+  background:rgba(10,15,24,.85);
+  color:#e5efff;
+  padding:10px 12px;
+  font-size:14px;
+}
+.form-control:focus{outline:none; border-color:rgba(91,209,255,.55); box-shadow:0 0 0 2px rgba(91,209,255,.2)}
 
 /* chat */
 .chat-layout{display:grid; grid-template-columns:1.4fr .9fr; gap:16px}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto" />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
+  <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -172,10 +173,18 @@
               </div>
             </div>
             <div class="section-actions">
-              <button id="addDeviceBtn" class="btn subtle" type="button">デバイス追加</button>
-              <button id="resetIoTBtn" class="btn subtle" type="button">リセット</button>
+              <button id="registerDeviceBtn" class="btn subtle" type="button">デバイス登録</button>
+              <button id="refreshDevicesBtn" class="btn subtle" type="button">最新の状態を取得</button>
             </div>
           </div>
+
+          <div
+            id="iotNotice"
+            class="iot-notice"
+            role="status"
+            aria-live="polite"
+            hidden
+          ></div>
 
           <div id="deviceGrid" class="device-grid" aria-live="polite"></div>
 
@@ -204,5 +213,53 @@
     </div>
 
   </div>
+
+  <dialog id="iotRegisterDialog" class="dialog" aria-labelledby="iotRegisterTitle">
+    <form id="iotRegisterForm" class="dialog-panel" autocomplete="off">
+      <header class="dialog-header">
+        <h3 id="iotRegisterTitle">デバイスを登録</h3>
+      </header>
+      <div class="dialog-body">
+        <p id="iotRegisterMessage" class="dialog-message">
+          エッジデバイスで使用する識別子を入力し、必要に応じて表示名やメモを設定してください。
+        </p>
+        <div class="form-row">
+          <label class="form-label" for="iotRegisterId">デバイスID</label>
+          <input
+            id="iotRegisterId"
+            class="form-control"
+            type="text"
+            name="device_id"
+            placeholder="例: device-abc123"
+            required
+          />
+        </div>
+        <div class="form-row">
+          <label class="form-label" for="iotRegisterName">表示名（任意）</label>
+          <input
+            id="iotRegisterName"
+            class="form-control"
+            type="text"
+            name="display_name"
+            placeholder="例: キッチンのセンサー"
+          />
+        </div>
+        <div class="form-row">
+          <label class="form-label" for="iotRegisterNote">メモ（任意）</label>
+          <input
+            id="iotRegisterNote"
+            class="form-control"
+            type="text"
+            name="note"
+            placeholder="設置場所など"
+          />
+        </div>
+      </div>
+      <footer class="dialog-footer">
+        <button id="iotRegisterCancel" class="btn ghost" type="button">キャンセル</button>
+        <button id="iotRegisterSubmit" class="btn primary" type="submit">登録</button>
+      </footer>
+    </form>
+  </dialog>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the IoT dashboard mock data with API-driven device rendering and management controls
- enable IoT agent chat through the shared sidebar and update navigation to handle the new mode
- proxy IoT agent requests in Flask and add styling for the refreshed dashboard and dialog

## Testing
- python -m compileall app.py assets

------
https://chatgpt.com/codex/tasks/task_e_68f883022e5c83209beb0dbe7d75de40