### PR TITLE
Use hosted IoT Agent as default fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ export FAQ_GEMINI_API_BASE="http://localhost:5000,http://faq_gemini:5000"
 python app.py
 ```
 
+同様に IoT ダッシュボードは既定で公開されている IoT Agent (`https://iot-agent.project-kk.com`) に接続します。別の IoT Agent を利用したい場合は、環境変数 `IOT_AGENT_API_BASE` を設定してください。複数候補をカンマ区切りで渡すと順番に接続を試行します。
+
+```bash
+export IOT_AGENT_API_BASE="https://your-iot-agent.example.com"
+python app.py
+```
+
 ## Docker Compose での起動
 
 ```bash

--- a/app.py
+++ b/app.py
@@ -16,7 +16,11 @@ DEFAULT_GEMINI_BASES = (
 )
 GEMINI_TIMEOUT = float(os.environ.get("FAQ_GEMINI_TIMEOUT", "30"))
 
+# Known upstream IoT Agent deployment that should be reachable from public environments.
+PUBLIC_IOT_AGENT_BASE = "https://iot-agent.project-kk.com"
+
 DEFAULT_IOT_AGENT_BASES = (
+    PUBLIC_IOT_AGENT_BASE,
     "http://localhost:5005",
     "http://iot_agent:5005",
 )

--- a/assets/app.js
+++ b/assets/app.js
@@ -247,6 +247,8 @@ const IOT_DEVICE_ICON = `<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3"
 
 const IOT_FETCH_INTERVAL = 6000;
 
+const PUBLIC_IOT_AGENT_BASE = "https://iot-agent.project-kk.com";
+
 const REGISTER_MESSAGE_DEFAULT = registerMessageEl?.textContent.trim() || "エッジデバイスで使用する識別子を入力し、必要に応じて表示名やメモを設定してください。";
 
 const iotState = {
@@ -276,6 +278,9 @@ function resolveIotAgentBase() {
   }
   if (window.location.origin && window.location.origin !== "null") {
     return `${window.location.origin.replace(/\/+$/, "")}/iot_agent`;
+  }
+  if (PUBLIC_IOT_AGENT_BASE) {
+    return PUBLIC_IOT_AGENT_BASE;
   }
   return "/iot_agent";
 }


### PR DESCRIPTION
## Summary
- default the server-side IoT proxy to the hosted agent deployment
- expose the same hosted URL as a browser fallback and document the override option

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68f88a297b548320b071d91ce21581b8