### PR TITLE
Adjust IoT device card width

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -546,6 +546,7 @@ body{
   gap:14px;
   margin-bottom:20px;
   align-items:stretch;
+  justify-content:flex-start;
 }
 
 .device-card{
@@ -560,6 +561,9 @@ body{
   flex-direction:column;
   gap:12px;
   min-height:0;
+  width:100%;
+  max-width:320px;
+  justify-self:flex-start;
   transition:transform .25s ease, box-shadow .25s ease, border-color .25s ease;
   backdrop-filter:blur(6px);
 }


### PR DESCRIPTION
## Summary
- limit IoT device cards to a compact width so single entries no longer stretch across the dashboard
- align the device grid layout to keep cards anchored to the left edge

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68f89becabbc83209f62a8f8d3008318