### PR TITLE
Update langchain-core dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.3
 requests==2.32.3
 langgraph==0.0.57
 langchain-openai==0.1.7
-langchain-core==0.1.36
+langchain-core==0.2.38


### PR DESCRIPTION
## Summary
- bump langchain-core to a 0.2.x release compatible with langgraph 0.0.57

## Testing
- not run (container image build requires Docker which is unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68f8a04d3c58832083f822ea68c99503