### PR TITLE
Show orchestrated agent view inside general screen

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -416,6 +416,23 @@ body{
   font-size:15px;
   line-height:1.8;
 }
+.general-view__default{display:flex; flex-direction:column; gap:16px}
+.general-view__status{
+  margin:0;
+  font-size:14px;
+  color:var(--muted);
+  line-height:1.7;
+}
+.general-view__proxy{
+  display:none;
+  flex-direction:column;
+  gap:20px;
+  margin-top:12px;
+}
+.general-view--has-proxy .general-view__proxy{display:flex}
+.general-view--has-proxy .general-view__default{display:none}
+.view.general-proxy-active{display:block; overflow:auto; flex:1; min-height:0}
+#view-browser.view.general-proxy-active{display:flex; flex-direction:column; flex:1; min-height:0; overflow:hidden}
 
 /* generic buttons */
 .btn{

--- a/index.html
+++ b/index.html
@@ -141,9 +141,13 @@
         <!-- 0) 一般ビュー -->
         <section id="view-general" class="view" aria-labelledby="appTitle">
           <div class="general-view">
-            <h2>ようこそ</h2>
-            <p>左側のボタンから目的のビューを選択できます。ここでは全体の概要やお知らせを表示することができます。</p>
-            <p class="general-view__hint">「一般」ビューでは LangGraph を利用したマルチエージェント・オーケストレーターが動作し、共通チャットに入力した内容から計画を立てて各エージェントへ指示を出します。他のビューを選択している間は、従来どおり各専門エージェントへ直接メッセージが送られます。</p>
+            <div id="generalDefaultContent" class="general-view__default">
+              <h2>ようこそ</h2>
+              <p>左側のボタンから目的のビューを選択できます。ここでは全体の概要やお知らせを表示することができます。</p>
+              <p class="general-view__hint">「一般」ビューでは LangGraph を利用したマルチエージェント・オーケストレーターが動作し、共通チャットに入力した内容から計画を立てて各エージェントへ指示を出します。他のビューを選択している間は、従来どおり各専門エージェントへ直接メッセージが送られます。</p>
+            </div>
+            <p id="generalProxyStatus" class="general-view__status" hidden></p>
+            <div id="generalProxyContainer" class="general-view__proxy" hidden></div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add proxy containers to the general view so it can host other agent sections when the orchestrator picks them
- style the general view proxy layout and ensure embedded sections render correctly outside their normal home
- enhance the front-end logic to relocate browser/IoT/chat views into the general panel based on orchestrator decisions and keep chat mode in sync

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f97daec3448320b532a5a1c0ec1cce