### PR TITLE
Point IoT Agent integration to public endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,8 +59,6 @@ PUBLIC_IOT_AGENT_BASE = "https://iot-agent.project-kk.com"
 
 DEFAULT_IOT_AGENT_BASES = (
     PUBLIC_IOT_AGENT_BASE,
-    "http://localhost:5005",
-    "http://iot_agent:5005",
 )
 IOT_AGENT_TIMEOUT = float(os.environ.get("IOT_AGENT_TIMEOUT", "30"))
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -446,37 +446,29 @@ function resolveIotAgentBase() {
     sanitize(queryBase),
     sanitize(window.IOT_AGENT_API_BASE),
     sanitize(document.querySelector("meta[name='iot-agent-api-base']")?.content),
+    sanitize(PUBLIC_IOT_AGENT_BASE),
   ];
   for (const base of sources) {
     if (base) return base;
   }
-  if (window.location.origin && window.location.origin !== "null") {
-    return `${window.location.origin.replace(/\/+$/, "")}/iot_agent`;
-  }
-  if (PUBLIC_IOT_AGENT_BASE) {
-    return PUBLIC_IOT_AGENT_BASE;
-  }
-  return "/iot_agent";
+  return PUBLIC_IOT_AGENT_BASE;
 }
 
 const IOT_AGENT_API_BASE = resolveIotAgentBase();
 
 function buildIotAgentUrl(path) {
   if (!path) {
-    return IOT_AGENT_API_BASE || "/iot_agent";
+    return IOT_AGENT_API_BASE || PUBLIC_IOT_AGENT_BASE;
   }
   if (/^https?:/i.test(path)) {
     return path;
   }
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const base = IOT_AGENT_API_BASE || "";
+  const base = IOT_AGENT_API_BASE || PUBLIC_IOT_AGENT_BASE || "";
   if (!base) {
     return normalizedPath;
   }
-  if (/^https?:/i.test(base)) {
-    return `${base.replace(/\/+$/, "")}${normalizedPath}`;
-  }
-  return `${base.replace(/\/+$/, "")}${normalizedPath}` || normalizedPath;
+  return `${base.replace(/\/+$/, "")}${normalizedPath}`;
 }
 
 async function iotAgentRequest(path, { method = "GET", headers = {}, body, signal } = {}) {

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto" />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
-  <meta name="iot-agent-api-base" content="/iot_agent" />
+  <meta name="iot-agent-api-base" content="https://iot-agent.project-kk.com" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- remove unreachable localhost IoT Agent fallbacks in the Flask proxy
- default the SPA to the public IoT Agent endpoint in its metadata and resolution logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9860945008320b3d86b1a75e3fe74