### PR TITLE
Limit IoT Agent default base to public endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export FAQ_GEMINI_API_BASE="http://localhost:5000,http://faq_gemini:5000"
 python app.py
 ```
 
-同様に IoT ダッシュボードは既定で公開されている IoT Agent (`https://iot-agent.project-kk.com`) に接続します。別の IoT Agent を利用したい場合は、環境変数 `IOT_AGENT_API_BASE` を設定してください。複数候補をカンマ区切りで渡すと順番に接続を試行します。
+同様に IoT ダッシュボードは既定で公開されている IoT Agent (`https://iot-agent.project-kk.com`) のみを利用します。別の IoT Agent を利用したい場合は、環境変数 `IOT_AGENT_API_BASE` を設定してください。複数候補をカンマ区切りで渡すと順番に接続を試行します。
 
 ```bash
 export IOT_AGENT_API_BASE="https://your-iot-agent.example.com"

--- a/app.py
+++ b/app.py
@@ -59,8 +59,6 @@ PUBLIC_IOT_AGENT_BASE = "https://iot-agent.project-kk.com"
 
 DEFAULT_IOT_AGENT_BASES = (
     PUBLIC_IOT_AGENT_BASE,
-    "http://localhost:5005",
-    "http://iot_agent:5005",
 )
 IOT_AGENT_TIMEOUT = float(os.environ.get("IOT_AGENT_TIMEOUT", "30"))
 


### PR DESCRIPTION
## Summary
- restrict the default IoT Agent base list to the public deployment
- document that the application now only connects to the public IoT Agent by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9860945008320b3d86b1a75e3fe74