### PR TITLE
Improve remote browser embed layout

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -325,7 +325,7 @@ function normalizeBrowserEmbedUrl(value) {
 
     const resizeValue = params.get("resize");
     if (!resizeValue || !ALLOWED_RESIZE_VALUES.has(resizeValue)) {
-      params.set("resize", "scale");
+      params.set("resize", "remote");
     }
 
     return url.toString();
@@ -364,7 +364,7 @@ function resolveBrowserEmbedUrl() {
     }
   }
 
-  return normalizeBrowserEmbedUrl("http://127.0.0.1:7900/?autoconnect=1&resize=scale");
+  return normalizeBrowserEmbedUrl("http://127.0.0.1:7900/?autoconnect=1&resize=remote");
 }
 
 const BROWSER_EMBED_URL = resolveBrowserEmbedUrl();
@@ -380,7 +380,6 @@ function ensureBrowserIframe() {
     iframe = document.createElement("iframe");
     iframe.setAttribute("title", "埋め込みブラウザ");
     iframe.setAttribute("allow", "fullscreen");
-    iframe.setAttribute("allowfullscreen", "");
     stage.appendChild(iframe);
   }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -450,23 +450,24 @@ body{
   background:var(--panel-2);
   border:1px solid var(--border);
   border-radius:var(--radius);
-  padding:12px;
   box-shadow:var(--shadow);
   display:flex;
   flex-direction:column;
   flex:1;
   min-height:0;
+  overflow:hidden;
+  position:relative;
 }
 
 .stage{
   width:100%;
-  min-height:420px;
+  min-height:clamp(420px, 65vh, 900px);
   flex:1;
   min-width:0;
   height:100%;
-  background:#0f1115;
-  border-radius:10px;
-  border:1px solid var(--border);
+  background:#05060a;
+  border-radius:0;
+  border:0;
   display:flex;
   align-items:center;
   justify-content:center;
@@ -476,11 +477,12 @@ body{
 }
 
 .stage iframe{
+  display:block;
   width:100%;
   height:100%;
   border:0;
-  border-radius:8px;
-  background:#0a0c10;
+  border-radius:0;
+  background:#000;
 }
 
 .stage-fallback{
@@ -492,11 +494,19 @@ body{
 }
 
 .browser-toolbar{
+  position:absolute;
+  top:16px;
+  right:16px;
   display:flex;
   justify-content:flex-end;
   align-items:center;
   gap:8px;
-  padding-top:10px;
+  padding:6px 10px;
+  border-radius:999px;
+  background:rgba(9,14,24,.72);
+  backdrop-filter:blur(8px);
+  box-shadow:0 8px 20px rgba(0,0,0,.45);
+  z-index:5;
 }
 
 /* IoT dashboard */

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto" />
+  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=remote&scale=auto" />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
   <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>


### PR DESCRIPTION
## Summary
- default the embedded Selenium Grid URL to use remote resizing so the canvas fills the available viewport
- drop the redundant allowfullscreen attribute and restyle the browser surface to occupy the full panel with an overlaid control chip

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f984ab4cd48320bdb61ecfdf64df95