### PR TITLE
Adjust noVNC embed to follow viewport size

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=remote&scale=auto" />
+  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto&view_clip=1" />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
   <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>


### PR DESCRIPTION
## Summary
- default the embedded noVNC client to auto scaling with clipping so the remote desktop can match the viewport
- sync the noVNC viewport when the browser view is shown or resized to keep the remote canvas within the visible area
- revert the prior CSS-based workaround now that scaling is handled by the embed configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f98bc416d08320a4491dd326d8fe2f