### PR TITLE
Update noVNC embed defaults to scale remote canvas

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -336,9 +336,8 @@ let generalBrowserController = null;
 const ALLOWED_RESIZE_VALUES = new Set(["scale", "remote", "off"]);
 const DEFAULT_NOVNC_PARAMS = {
   autoconnect: "1",
-  resize: "remote",
+  resize: "scale",
   scale: "auto",
-  view_clip: "1",
 };
 
 function normalizeBrowserEmbedUrl(value) {
@@ -355,10 +354,6 @@ function normalizeBrowserEmbedUrl(value) {
 
     if (!params.has("scale") || !params.get("scale")) {
       params.set("scale", DEFAULT_NOVNC_PARAMS.scale);
-    }
-
-    if (!params.has("view_clip") || !params.get("view_clip")) {
-      params.set("view_clip", DEFAULT_NOVNC_PARAMS.view_clip);
     }
 
     if (!params.has("autoconnect") || !params.get("autoconnect")) {
@@ -401,7 +396,7 @@ function resolveBrowserEmbedUrl() {
     }
   }
 
-  return normalizeBrowserEmbedUrl("http://127.0.0.1:7900/?autoconnect=1&resize=remote&scale=auto&view_clip=1");
+  return normalizeBrowserEmbedUrl("http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto");
 }
 
 const BROWSER_EMBED_URL = resolveBrowserEmbedUrl();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=remote&scale=auto&view_clip=1" />
+  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto" />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
   <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>


### PR DESCRIPTION
## Summary
- default the SPA's noVNC parameters to resize via scale and drop the view_clip flag
- ensure the embed normalisation and fallback URL align with the new defaults
- update the shipped browser-embed meta tag to match the scaled behaviour

## Testing
- Manual verification of ブラウザ view with stub noVNC page
- Manual verification of 一般 view showing proxied ブラウザ content with stub noVNC page


------
https://chatgpt.com/codex/tasks/task_e_68f9a35395648320898aa4ecfc7fbff0