### PR TITLE
Expand remote browser stage to fill available height

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -460,15 +460,16 @@ body{
   flex-direction:column;
   flex:1;
   min-height:0;
+  height:100%;
   overflow:hidden;
   position:relative;
 }
 
 .stage{
   width:100%;
-  min-height:clamp(420px, 65vh, 900px);
-  flex:1;
+  flex:1 1 auto;
   min-width:0;
+  min-height:0;
   height:100%;
   background:#05060a;
   border-radius:0;


### PR DESCRIPTION
## Summary
- allow the remote browser surface to stretch vertically with its container by letting the wrapper and stage take the full height
- adjust the stage flex sizing so the embedded browser can use the entire column

## Testing
- python -m http.server 8000 (manual check)


------
https://chatgpt.com/codex/tasks/task_e_68f9b7d582308320bb850b6bb1f083e3