### PR TITLE
Unify thinking message styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -967,15 +967,6 @@ body{
   margin-top:14px;
   opacity:.65;
 }
-.sidebar-chat-log .msg.assistant.thinking{
-  background:linear-gradient(160deg, rgba(38,66,110,.92), rgba(20,38,78,.85));
-  border:1px solid rgba(91,209,255,.45);
-  padding:16px;
-}
-.sidebar-chat-log .msg.assistant.thinking .thinking-text{
-  background:rgba(10,20,40,.55);
-  border-color:rgba(91,209,255,.4);
-}
 .msg.pending{opacity:.78; font-style:italic}
 .msg-time{display:block; opacity:.6; font-size:11px; margin-top:4px}
 .chat-form{display:flex; gap:8px; padding:10px; border-top:1px solid var(--border)}


### PR DESCRIPTION
## Summary
- remove sidebar-specific styling overrides for pending assistant messages so they match the main chat appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68faaa1301388320ae04286ce5497759