### PR TITLE
Refine assistant thinking indicator UI

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1715,6 +1715,9 @@ function createMessageElement(message, { compact = false } = {}) {
   const time = message.ts ? new Date(message.ts).toLocaleString("ja-JP") : "";
   const text = message.text ?? "";
   const escapedText = escapeHTML(text);
+  const trimmedText = text.trim();
+  const hasDetail = trimmedText.length > 0;
+  const escapedDetail = hasDetail ? escapeHTML(trimmedText) : "";
 
   if (message.role === "assistant" && message.pending) {
     el.classList.add("thinking");
@@ -1724,15 +1727,8 @@ function createMessageElement(message, { compact = false } = {}) {
         <span class="thinking-labels">
           <span class="thinking-title">AI が考えています</span>
           <span class="thinking-sub">見つけた情報から回答を組み立て中…</span>
+          ${hasDetail ? `<span class="thinking-detail">${escapedDetail}</span>` : ""}
         </span>
-      </div>
-      <div class="thinking-body">
-        <p class="thinking-text">${escapedText || "回答を生成しています…"}</p>
-        <div class="thinking-steps" aria-hidden="true">
-          <span></span>
-          <span></span>
-          <span></span>
-        </div>
       </div>
       ${time ? `<span class="msg-time">${time}</span>` : ""}
     `;
@@ -2389,7 +2385,7 @@ function addUserMessage(text) {
 function addPendingAssistantMessage() {
   const message = {
     role: "assistant",
-    text: "回答を生成しています…",
+    text: "",
     pending: true,
   };
   chatState.messages.push(message);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -900,15 +900,21 @@ body{
 }
 .thinking-header{
   display:flex;
-  align-items:center;
+  align-items:flex-start;
   gap:12px;
-  margin-bottom:12px;
+  margin-bottom:0;
   position:relative;
   z-index:1;
 }
-.thinking-labels{display:flex; flex-direction:column; gap:2px;}
+.thinking-labels{display:flex; flex-direction:column; gap:4px;}
 .thinking-title{font-size:13px; font-weight:600; letter-spacing:.04em; text-transform:none;}
 .thinking-sub{font-size:11px; color:rgba(230,233,239,.75); letter-spacing:.02em;}
+.thinking-detail{
+  font-size:12px;
+  line-height:1.7;
+  color:rgba(220,230,247,.82);
+  letter-spacing:.02em;
+}
 .thinking-orb{
   width:14px;
   height:14px;
@@ -926,40 +932,6 @@ body{
   opacity:.9;
   animation:thinkingOrbPulse 2s ease-in-out infinite;
 }
-.thinking-body{
-  position:relative;
-  z-index:1;
-  display:flex;
-  flex-direction:column;
-  gap:12px;
-}
-.thinking-text{
-  margin:0;
-  padding:12px 14px;
-  background:rgba(8,16,32,.6);
-  border-radius:14px;
-  border:1px solid rgba(91,209,255,.3);
-  font-size:13px;
-  line-height:1.75;
-  color:#dce6f7;
-  white-space:pre-wrap;
-}
-.thinking-steps{
-  display:flex;
-  align-items:center;
-  gap:8px;
-}
-.thinking-steps span{
-  display:block;
-  width:10px;
-  height:10px;
-  border-radius:50%;
-  background:rgba(91,209,255,.55);
-  box-shadow:0 0 10px rgba(91,209,255,.55);
-  animation:thinkingDot 1.35s ease-in-out infinite;
-}
-.thinking-steps span:nth-child(2){animation-delay:.2s;}
-.thinking-steps span:nth-child(3){animation-delay:.4s;}
 .msg.assistant.thinking .msg-time{
   position:relative;
   z-index:1;
@@ -1143,12 +1115,6 @@ body{
   0%{transform:scale(.8); opacity:.6;}
   50%{transform:scale(1); opacity:1;}
   100%{transform:scale(.8); opacity:.6;}
-}
-
-@keyframes thinkingDot{
-  0%, 100%{transform:translateY(0); opacity:.6;}
-  30%{transform:translateY(-4px); opacity:1;}
-  60%{transform:translateY(2px); opacity:.8;}
 }
 
 @keyframes thinkingGlow{


### PR DESCRIPTION
## Summary
- update assistant pending message rendering to always use the "AI が考えています" header with optional status detail
- drop the old loading bubble/dot layout and tighten styles around the new thinking header
- clear the placeholder pending text so interim messages rely on the unified indicator

## Testing
- python app.py


------
https://chatgpt.com/codex/tasks/task_e_68fab75591c483209450103b709b4997