### PR TITLE
Handle browser agent prompt asynchronously

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2453,7 +2453,17 @@ async function sendOrchestratorMessage(text) {
           if (agentRaw === "browser") {
             ensureBrowserAgentInitialized({ showLoading: true });
             if (commandText) {
-              await sendBrowserAgentPrompt(commandText);
+              const runPromise = sendBrowserAgentPrompt(commandText);
+              runPromise.catch(error => {
+                console.error("Browser agent prompt failed", error);
+                const errorMessage = error && typeof error.message === "string"
+                  ? error.message
+                  : String(error ?? "不明なエラー");
+                addOrchestratorAssistantMessage(
+                  `[ブラウザエージェント] ブラウザ操作の実行中にエラーが発生しました: ${errorMessage}`
+                );
+                renderOrchestratorChat({ forceSidebar: currentChatMode === "orchestrator" });
+              });
             }
           }
         }


### PR DESCRIPTION
## Summary
- trigger browser agent prompts without blocking the orchestrator SSE loop
- surface browser agent failures in the orchestrator chat and refresh the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd2cc2ad908320a3bc48f643c4d533