### PR TITLE
Fix orchestrator chat updates in general view

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -260,7 +260,7 @@ function activateView(viewKey) {
     ensureChatInitialized();
   }
   if (isBrowserView) {
-    ensureBrowserAgentInitialized({ showLoading: true });
+    ensureBrowserAgentInitialized({ showLoading: true, forceSidebar: true });
     requestMainBrowserViewportSync({ reloadFallback: true });
   }
   if (isIotView) {
@@ -2203,13 +2203,13 @@ function connectBrowserEventStream() {
   }
 }
 
-function ensureBrowserAgentInitialized({ showLoading = false } = {}) {
+function ensureBrowserAgentInitialized({ showLoading = false, forceSidebar = false } = {}) {
   connectBrowserEventStream();
   if (!browserChatState.initialized) {
     browserChatState.initialized = true;
-    loadBrowserAgentHistory({ showLoading: true, forceSidebar: true });
+    loadBrowserAgentHistory({ showLoading: true, forceSidebar });
   } else {
-    loadBrowserAgentHistory({ showLoading, forceSidebar: true });
+    loadBrowserAgentHistory({ showLoading, forceSidebar });
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid forcing browser chat history into the sidebar when initializing from non-browser views
- ensure the browser view still forces its chat history into the sidebar when activated so existing behaviour remains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd3115c8f08320a14e17d62e7ce9d7