### PR TITLE
Fix orchestrator placeholder initialization order

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2527,6 +2527,17 @@ async function sendOrchestratorMessage(text) {
         const agentRaw = typeof task.agent === "string" ? task.agent.trim().toLowerCase() : "";
         const commandText = typeof task.command === "string" ? task.command.trim() : "";
         const agentLabel = agentRaw ? (ORCHESTRATOR_AGENT_LABELS[agentRaw] || agentRaw) : "エージェント";
+        const displayText = commandText
+          ? `[${agentLabel}] ${commandText}`
+          : `[${agentLabel}] タスクを実行しています…`;
+        const message = addOrchestratorAssistantMessage(displayText, { pending: true });
+        message.ts = Date.now();
+        if (taskIndex !== null) {
+          const entry = ensureTaskEntry(taskIndex);
+          if (entry) {
+            entry.placeholder = message;
+          }
+        }
         if (agentRaw) {
           setGeneralProxyAgent(agentRaw);
           if (agentRaw === "browser") {
@@ -2545,17 +2556,6 @@ async function sendOrchestratorMessage(text) {
                 renderOrchestratorChat({ forceSidebar: currentChatMode === "orchestrator" });
               });
             }
-          }
-        }
-        const displayText = commandText
-          ? `[${agentLabel}] ${commandText}`
-          : `[${agentLabel}] タスクを実行しています…`;
-        const message = addOrchestratorAssistantMessage(displayText, { pending: true });
-        message.ts = Date.now();
-        if (taskIndex !== null) {
-          const entry = ensureTaskEntry(taskIndex);
-          if (entry) {
-            entry.placeholder = message;
           }
         }
         continue;


### PR DESCRIPTION
## Summary
- create the orchestrator task status message before using it as a placeholder for the browser mirror
- avoid accessing the message reference before initialization to prevent the runtime error seen after task submission

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fd374d402483208c149f30b66128a7