### PR TITLE
Update browser agent configuration to match web service alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Flask をベースにしたマルチエージェント・プラットフォー�
 | `OPENAI_API_KEY` | LangGraph オーケストレーターが利用する OpenAI API キー。`.env` に記述して読み込まれます。 | (必須) |
 | `FAQ_GEMINI_API_BASE` | FAQ_Gemini のベース URL をカンマ区切りで列挙。先頭から順に接続を試行します。 | `http://localhost:5000,http://faq_gemini:5000` |
 | `FAQ_GEMINI_TIMEOUT` | FAQ_Gemini へのタイムアウト (秒)。 | `30` |
-| `BROWSER_AGENT_API_BASE` | Browser Agent のベース URL をカンマ区切りで列挙。 | `http://localhost:5005,http://browser_agent:5005` |
+| `BROWSER_AGENT_API_BASE` | Browser Agent のベース URL をカンマ区切りで列挙。 | `http://localhost:5005,http://web:5005` |
 | `BROWSER_AGENT_TIMEOUT` | Browser Agent へのタイムアウト (秒)。 | `120` |
 | `IOT_AGENT_API_BASE` | IoT Agent のベース URL をカンマ区切りで列挙。 | `https://iot-agent.project-kk.com` |
 | `IOT_AGENT_TIMEOUT` | IoT Agent へのタイムアウト (秒)。 | `30` |
 | `ORCHESTRATOR_MODEL` | ChatOpenAI で使用するモデル名。 | `gpt-4.1-2025-04-14` |
 | `ORCHESTRATOR_MAX_TASKS` | プランで生成されるタスクの最大数。 | `5` |
 
-`.env` ファイルを作成すると `app.py` の `_load_env_file()` により自動で読み込まれます。
+`.env` ファイルを作成すると `app.py` の `_load_env_file()` により自動で読み込まれます。Browser Agent など Docker 上のサービスに接続する場合は、Compose ファイルで指定したサービス名やネットワークエイリアス (例: `web`) と `*_API_BASE` のホスト部分を一致させてください。
 
 ## ローカル開発手順
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "5050:5050"
     environment:
       FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
-      BROWSER_AGENT_API_BASE: "http://browser_agent:5005,http://localhost:5005"
+      BROWSER_AGENT_API_BASE: "http://web:5005,http://localhost:5005"
       FLASK_DEBUG: "1"
     volumes:
       - .:/app


### PR DESCRIPTION
## Summary
- update the browser agent base URL in docker-compose to use the web service DNS name alongside the localhost fallback
- document that API base hostnames must match the Docker service name or network alias used by the browser agent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd3ad29f78832098d545beecdf2248