### PR TITLE
Update browser agent default endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ IOT_AGENT_TIMEOUT = float(os.environ.get("IOT_AGENT_TIMEOUT", "30"))
 
 DEFAULT_BROWSER_AGENT_BASES = (
     "http://localhost:5005",
-    "http://browser_agent:5005",
+    "http://web:5005",
 )
 BROWSER_AGENT_TIMEOUT = float(os.environ.get("BROWSER_AGENT_TIMEOUT", "120"))
 


### PR DESCRIPTION
## Summary
- replace the obsolete `http://browser_agent:5005` fallback with the correct `http://web:5005` host for the Browser Agent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd423774948320bd5fffe4cfd2ce0d