### PR TITLE
Update Browser Agent defaults and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Flask をベースにしたマルチエージェント・プラットフォー�
 | `OPENAI_API_KEY` | LangGraph オーケストレーターが利用する OpenAI API キー。`.env` に記述して読み込まれます。 | (必須) |
 | `FAQ_GEMINI_API_BASE` | FAQ_Gemini のベース URL をカンマ区切りで列挙。先頭から順に接続を試行します。 | `http://localhost:5000,http://faq_gemini:5000` |
 | `FAQ_GEMINI_TIMEOUT` | FAQ_Gemini へのタイムアウト (秒)。 | `30` |
-| `BROWSER_AGENT_API_BASE` | Browser Agent のベース URL をカンマ区切りで列挙。 | `http://localhost:5005,http://web:5005` |
+| `BROWSER_AGENT_API_BASE` | Browser Agent のベース URL をカンマ区切りで列挙。 | `http://browser-agent:5005,http://localhost:5005` |
 | `BROWSER_AGENT_TIMEOUT` | Browser Agent へのタイムアウト (秒)。 | `120` |
 | `IOT_AGENT_API_BASE` | IoT Agent のベース URL をカンマ区切りで列挙。 | `https://iot-agent.project-kk.com` |
 | `IOT_AGENT_TIMEOUT` | IoT Agent へのタイムアウト (秒)。 | `30` |
@@ -92,6 +92,12 @@ Docker を利用すると依存関係をホストにインストールせずに�
 ```bash
 docker compose up --build
 ```
+
+- Browser Agent を Docker コンテナとして起動している場合は、`docker run` などでポート `5005` を公開し、`multi_agent_platform_net`
+  (または `MULTI_AGENT_NETWORK` で指定したネットワーク名) に接続してください。例: `docker run --rm -p 5005:5005 --network multi_agent_platform_net browser-agent`。
+- すでに起動済みの Browser Agent に接続する場合は、`.env` や `docker-compose.yml` の `BROWSER_AGENT_API_BASE` をそのホスト名
+  (例: `http://browser-agent:5005` または `http://host.docker.internal:5005`) に合わせてください。
+- 上記の準備が整ったら `docker compose up --build` で `web` サービスを再起動し、`/orchestrator/chat` からブラウザタスクが実行できることを確認します。
 
 - `docker-compose.yml` はホットリロード向けにリポジトリをボリュームマウントし、`FLASK_DEBUG=1` で開発モードを有効にします。
 - 外部の FAQ_Gemini / Browser Agent / IoT Agent コンテナを同じネットワークに接続する場合は、`MULTI_AGENT_NETWORK` 環境変数で共有ネットワーク名を指定してください (既定: `multi_agent_platform_net`)。

--- a/app.py
+++ b/app.py
@@ -74,8 +74,8 @@ DEFAULT_IOT_AGENT_BASES = (
 IOT_AGENT_TIMEOUT = float(os.environ.get("IOT_AGENT_TIMEOUT", "30"))
 
 DEFAULT_BROWSER_AGENT_BASES = (
+    "http://browser-agent:5005",
     "http://localhost:5005",
-    "http://web:5005",
 )
 BROWSER_AGENT_TIMEOUT = float(os.environ.get("BROWSER_AGENT_TIMEOUT", "120"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "5050:5050"
     environment:
       FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
-      BROWSER_AGENT_API_BASE: "http://web:5005,http://localhost:5005"
+      BROWSER_AGENT_API_BASE: "http://browser-agent:5005,http://localhost:5005"
       FLASK_DEBUG: "1"
     volumes:
       - .:/app


### PR DESCRIPTION
## Summary
- update the Browser Agent default base URLs to prioritise the `browser-agent` service name
- document the steps for wiring an external Browser Agent into the shared Docker network

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68fd541a9e7c8320b301df06dc634c33