### PR TITLE
Ensure embedded remote Chrome sessions start maximized

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -341,6 +341,7 @@ const DEFAULT_NOVNC_PARAMS = {
   autoconnect: "1",
   resize: "scale",
   scale: "auto",
+  view_clip: "false",
 };
 
 function normalizeBrowserEmbedUrl(value) {
@@ -349,6 +350,10 @@ function normalizeBrowserEmbedUrl(value) {
   try {
     const url = new URL(value, window.location.origin);
     const params = url.searchParams;
+
+    if (!url.pathname || url.pathname === "/") {
+      url.pathname = "/vnc_lite.html";
+    }
 
     const resizeValue = params.get("resize");
     if (!resizeValue || !ALLOWED_RESIZE_VALUES.has(resizeValue)) {
@@ -361,6 +366,10 @@ function normalizeBrowserEmbedUrl(value) {
 
     if (!params.has("autoconnect") || !params.get("autoconnect")) {
       params.set("autoconnect", DEFAULT_NOVNC_PARAMS.autoconnect);
+    }
+
+    if (!params.has("view_clip") || params.get("view_clip") !== "false") {
+      params.set("view_clip", DEFAULT_NOVNC_PARAMS.view_clip);
     }
 
     return url.toString();
@@ -399,7 +408,9 @@ function resolveBrowserEmbedUrl() {
     }
   }
 
-  return normalizeBrowserEmbedUrl("http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto");
+  return normalizeBrowserEmbedUrl(
+    "http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false",
+  );
 }
 
 const BROWSER_EMBED_URL = resolveBrowserEmbedUrl();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto" />
+  <meta
+    name="browser-embed-url"
+    content="http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false"
+  />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
   <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>


### PR DESCRIPTION
## Summary
- update the default embedded noVNC URL to use the vnc_lite page with view clipping disabled so the remote Chrome window opens maximized
- normalize custom embed URLs by enforcing vnc_lite.html, resize/scale defaults, and a view_clip=false parameter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fdc03830348320abdb8b0a547cf2e6