### PR TITLE
Ensure embedded browser iframe matches maximized remote session

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -341,6 +341,7 @@ const DEFAULT_NOVNC_PARAMS = {
   autoconnect: "1",
   resize: "scale",
   scale: "auto",
+  view_clip: "false",
 };
 
 function normalizeBrowserEmbedUrl(value) {
@@ -350,17 +351,25 @@ function normalizeBrowserEmbedUrl(value) {
     const url = new URL(value, window.location.origin);
     const params = url.searchParams;
 
-    const resizeValue = params.get("resize");
-    if (!resizeValue || !ALLOWED_RESIZE_VALUES.has(resizeValue)) {
-      params.set("resize", DEFAULT_NOVNC_PARAMS.resize);
-    }
+    for (const [key, defaultValue] of Object.entries(DEFAULT_NOVNC_PARAMS)) {
+      const currentValue = params.get(key);
+      if (key === "resize") {
+        if (!currentValue || !ALLOWED_RESIZE_VALUES.has(currentValue)) {
+          params.set(key, defaultValue);
+        }
+        continue;
+      }
 
-    if (!params.has("scale") || !params.get("scale")) {
-      params.set("scale", DEFAULT_NOVNC_PARAMS.scale);
-    }
+      if (key === "view_clip") {
+        if (currentValue?.toLowerCase() !== defaultValue) {
+          params.set(key, defaultValue);
+        }
+        continue;
+      }
 
-    if (!params.has("autoconnect") || !params.get("autoconnect")) {
-      params.set("autoconnect", DEFAULT_NOVNC_PARAMS.autoconnect);
+      if (!currentValue) {
+        params.set(key, defaultValue);
+      }
     }
 
     return url.toString();
@@ -399,7 +408,9 @@ function resolveBrowserEmbedUrl() {
     }
   }
 
-  return normalizeBrowserEmbedUrl("http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto");
+  return normalizeBrowserEmbedUrl(
+    "http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false",
+  );
 }
 
 const BROWSER_EMBED_URL = resolveBrowserEmbedUrl();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <meta name="browser-embed-url" content="http://127.0.0.1:7900/?autoconnect=1&resize=scale&scale=auto" />
+  <meta
+    name="browser-embed-url"
+    content="http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false"
+  />
   <meta name="browser-agent-api-base" content="http://localhost:5005" />
   <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>


### PR DESCRIPTION
## Summary
- align the default embedded noVNC URL with the web_agent02 configuration so the remote Chrome window fills the frame when maximized
- enforce required query parameters (including view_clip=false) when normalizing the browser iframe source to keep the layout consistent across general and browser views

## Testing
- python -m compileall app.py assets

------
https://chatgpt.com/codex/tasks/task_e_68fdcca53ed0832080f157abd096166d