### PR TITLE
Add runtime browser embed configuration for remote agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,16 @@ Flask をベースにしたマルチエージェント・プラットフォー�
 | `FAQ_GEMINI_API_BASE` | FAQ_Gemini のベース URL をカンマ区切りで列挙。先頭から順に接続を試行します。 | `http://localhost:5000,http://faq_gemini:5000` |
 | `FAQ_GEMINI_TIMEOUT` | FAQ_Gemini へのタイムアウト (秒)。 | `30` |
 | `BROWSER_AGENT_API_BASE` | Browser Agent のベース URL をカンマ区切りで列挙。 | `http://browser-agent:5005,http://localhost:5005` |
+| `BROWSER_EMBED_URL` | リモートブラウザ iframe の noVNC URL。未設定時は `config.js` が既定の 7900 ポート URL を提供します。 | *(省略時は既定値)* |
 | `BROWSER_AGENT_TIMEOUT` | Browser Agent へのタイムアウト (秒)。 | `120` |
 | `IOT_AGENT_API_BASE` | IoT Agent のベース URL をカンマ区切りで列挙。 | `https://iot-agent.project-kk.com` |
 | `IOT_AGENT_TIMEOUT` | IoT Agent へのタイムアウト (秒)。 | `30` |
 | `ORCHESTRATOR_MODEL` | ChatOpenAI で使用するモデル名。 | `gpt-4.1-2025-04-14` |
 | `ORCHESTRATOR_MAX_TASKS` | プランで生成されるタスクの最大数。 | `5` |
+
+`BROWSER_EMBED_URL` は [kota-kawa/web_agent02](https://github.com/kota-kawa/web_agent02) のブラウザエージェントが提供する noVNC
+エンドポイント（例: `http://browser-agent:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false`）を指定すると、最大化された
+Chrome ウィンドウをそのまま埋め込み表示できます。
 
 `.env` ファイルを作成すると `app.py` の `_load_env_file()` により自動で読み込まれます。Browser Agent など Docker 上のサービスに接続する場合は、Compose ファイルで指定したサービス名やネットワークエイリアス (例: `web`) と `*_API_BASE` のホスト部分を一致させてください。
 
@@ -73,6 +78,7 @@ Flask をベースにしたマルチエージェント・プラットフォー�
    OPENAI_API_KEY=sk-...
    FAQ_GEMINI_API_BASE=http://localhost:5000
    BROWSER_AGENT_API_BASE=http://localhost:5005
+   BROWSER_EMBED_URL=http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false
    IOT_AGENT_API_BASE=http://localhost:6000
    EOF
    ```

--- a/assets/app.js
+++ b/assets/app.js
@@ -1981,6 +1981,12 @@ const BROWSER_AGENT_BASE_HINTS = (() => {
     queryValue = "";
   }
 
+  if (Array.isArray(window.BROWSER_AGENT_BASE_HINTS)) {
+    for (const hint of window.BROWSER_AGENT_BASE_HINTS) {
+      addCandidate(hint);
+    }
+  }
+
   addCandidate(queryValue);
   addCandidate(window.BROWSER_AGENT_API_BASE);
   const metaContent = document.querySelector("meta[name='browser-agent-api-base']")?.content;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       FAQ_GEMINI_API_BASE: "http://faq_gemini:5000,http://localhost:5000"
       BROWSER_AGENT_API_BASE: "http://browser-agent:5005,http://localhost:5005"
+      BROWSER_EMBED_URL: "http://browser-agent:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false"
       FLASK_DEBUG: "1"
     volumes:
       - .:/app

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./assets/styles.css" />
+  <script src="/config.js"></script>
   <script src="./assets/app.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- expose the configured browser embed URL and agent bases through a new /config.js endpoint consumed by the SPA
- ensure the front-end prefers server-provided hints when resolving Browser Agent endpoints and load config before app.js
- document the new BROWSER_EMBED_URL environment variable and provide defaults for docker compose and sample .env usage

## Testing
- python -m compileall app.py assets/app.js

------
https://chatgpt.com/codex/tasks/task_e_68fdd9a32c2c8320af822956943b98af