### PR TITLE
Expose configurable browser embed URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Flask をベースにしたマルチエージェント・プラットフォー�
 | `FAQ_GEMINI_API_BASE` | FAQ_Gemini のベース URL をカンマ区切りで列挙。先頭から順に接続を試行します。 | `http://localhost:5000,http://faq_gemini:5000` |
 | `FAQ_GEMINI_TIMEOUT` | FAQ_Gemini へのタイムアウト (秒)。 | `30` |
 | `BROWSER_AGENT_API_BASE` | Browser Agent のベース URL をカンマ区切りで列挙。 | `http://browser-agent:5005,http://localhost:5005` |
+| `BROWSER_AGENT_CLIENT_BASE` | ブラウザから Browser Agent API にアクセスするためのベース URL。 | `http://localhost:5005` |
+| `BROWSER_EMBED_URL` | 一般ビューやブラウザビューで埋め込むリモートブラウザの URL。 | `http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false` |
 | `BROWSER_AGENT_TIMEOUT` | Browser Agent へのタイムアウト (秒)。 | `120` |
 | `IOT_AGENT_API_BASE` | IoT Agent のベース URL をカンマ区切りで列挙。 | `https://iot-agent.project-kk.com` |
 | `IOT_AGENT_TIMEOUT` | IoT Agent へのタイムアウト (秒)。 | `30` |
@@ -97,6 +99,10 @@ docker compose up --build
   (または `MULTI_AGENT_NETWORK` で指定したネットワーク名) に接続してください。例: `docker run --rm -p 5005:5005 --network multi_agent_platform_net browser-agent`。
 - すでに起動済みの Browser Agent に接続する場合は、`.env` や `docker-compose.yml` の `BROWSER_AGENT_API_BASE` をそのホスト名
   (例: `http://browser-agent:5005` または `http://host.docker.internal:5005`) に合わせてください。
+- `BROWSER_AGENT_CLIENT_BASE` と `BROWSER_EMBED_URL` を併せて設定すると、クライアント側のブラウザから直接アクセスできる URL を
+  伝播できます。例えば [`kota-kawa/web_agent02`](https://github.com/kota-kawa/web_agent02) の `docker compose up` で立ち上がる noVNC
+  セッションをそのまま利用したい場合は、`BROWSER_AGENT_CLIENT_BASE=http://127.0.0.1:5005` と
+  `BROWSER_EMBED_URL=http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false` を指定すると Chrome ウィンドウが常に最大化された状態で埋め込まれます。
 - 上記の準備が整ったら `docker compose up --build` で `web` サービスを再起動し、`/orchestrator/chat` からブラウザタスクが実行できることを確認します。
 
 - `docker-compose.yml` はホットリロード向けにリポジトリをボリュームマウントし、`FLASK_DEBUG=1` で開発モードを有効にします。
@@ -118,7 +124,7 @@ docker compose up --build
 ## プロジェクト構成
 
 - `app.py` : Flask アプリケーションおよびマルチエージェント・オーケストレーターの実装。
-- `index.html` と `assets/` : ユーザーインターフェースとなる静的フロントエンド資産。
+- `templates/index.html` と `assets/` : ユーザーインターフェースとなる静的フロントエンド資産。
 - `requirements.txt` : Python 依存パッケージ一覧。
 - `Dockerfile` : コンテナビルド設定 (`python:3.11-slim` ベース)。
 - `docker-compose.yml` : 開発用 Compose 設定。外部ネットワーク `multi_agent_platform_net` を前提にしています。

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,15 +5,19 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta
     name="browser-embed-url"
-    content="http://127.0.0.1:7900/vnc_lite.html?autoconnect=1&resize=scale&scale=auto&view_clip=false"
+    content="{{ browser_embed_url | e }}"
   />
-  <meta name="browser-agent-api-base" content="http://localhost:5005" />
+  <meta name="browser-agent-api-base" content="{{ browser_agent_client_base | e }}" />
   <meta name="iot-agent-api-base" content="/iot_agent" />
   <title>リモートブラウザ / IoT / 要約チャット - Single Page UI</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./assets/styles.css" />
+  <script>
+    window.BROWSER_EMBED_URL = {{ browser_embed_url | tojson }};
+    window.BROWSER_AGENT_API_BASE = {{ browser_agent_client_base | tojson }};
+  </script>
   <script src="./assets/app.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- render the single-page UI through a template so we can inject runtime configuration
- allow overriding the embedded browser URL and Browser Agent client base via environment variables and document how to reuse the maximised web_agent02 browser

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68fddd84a23c8320881bca451859c152