### PR TITLE
feat: Enable follow-up prompts to browser agent in General view

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2190,7 +2190,8 @@ function updateSidebarControlsForMode(mode) {
       sidebarResetBtn.disabled = !isBrowserAgentActive;
     }
     if (sidebarChatSend) {
-      sidebarChatSend.disabled = orchestratorState.sending;
+      const sending = isBrowserAgentActive ? browserChatState.sending : orchestratorState.sending;
+      sidebarChatSend.disabled = sending;
     }
     if (isBrowserAgentActive) {
       updatePauseButtonState(mode);
@@ -2800,10 +2801,19 @@ if (chatForm) {
     if (!value) return;
     chatInput.value = "";
     if (sidebarChatInput) sidebarChatInput.value = "";
-    if (currentChatMode === "browser") await sendBrowserAgentPrompt(value);
-    else if (currentChatMode === "iot") await sendIotChatMessage(value);
-    else if (currentChatMode === "orchestrator") await sendOrchestratorMessage(value);
-    else await sendChatMessage(value);
+    if (currentChatMode === "browser") {
+      await sendBrowserAgentPrompt(value);
+    } else if (currentChatMode === "iot") {
+      await sendIotChatMessage(value);
+    } else if (currentChatMode === "orchestrator") {
+      if (generalProxyAgentKey === "browser") {
+        await sendBrowserAgentPrompt(value);
+      } else {
+        await sendOrchestratorMessage(value);
+      }
+    } else {
+      await sendChatMessage(value);
+    }
   });
 }
 
@@ -2814,10 +2824,19 @@ if (sidebarChatForm) {
     if (!value) return;
     sidebarChatInput.value = "";
     if (chatInput) chatInput.value = "";
-    if (currentChatMode === "browser") await sendBrowserAgentPrompt(value);
-    else if (currentChatMode === "iot") await sendIotChatMessage(value);
-    else if (currentChatMode === "orchestrator") await sendOrchestratorMessage(value);
-    else await sendChatMessage(value);
+    if (currentChatMode === "browser") {
+      await sendBrowserAgentPrompt(value);
+    } else if (currentChatMode === "iot") {
+      await sendIotChatMessage(value);
+    } else if (currentChatMode === "orchestrator") {
+      if (generalProxyAgentKey === "browser") {
+        await sendBrowserAgentPrompt(value);
+      } else {
+        await sendOrchestratorMessage(value);
+      }
+    } else {
+      await sendChatMessage(value);
+    }
   });
 }
 


### PR DESCRIPTION
This change allows users to send additional prompts to the browser agent directly from the "General" view, even while an orchestration plan is in progress.

Previously, the chat input was disabled during orchestration, preventing interactive follow-up commands. This has been resolved by:
- Modifying the chat submission logic to route prompts directly to the browser agent when it is active in the "General" view.
- Updating the send button's state to reflect the browser agent's status, ensuring it becomes enabled as soon as a task is complete.